### PR TITLE
fix: corrupted encoding of special characters

### DIFF
--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -30,8 +30,8 @@ require_once URLSLAB_PLUGIN_DIR . '/includes/cron/class-urlslab-screenshot-cron.
  * @package    urlslab
  * @subpackage urlslab/includes
  */
-class Urlslab
-{
+class Urlslab {
+
 
 	/**
 	 * The loader that's responsible for maintaining and registering all hooks that power
@@ -75,9 +75,8 @@ class Urlslab
 	 *
 	 * @since    1.0.0
 	 */
-	public function __construct()
-	{
-		$this->version = URLSLAB_VERSION;
+	public function __construct() {
+		 $this->version = URLSLAB_VERSION;
 		$this->urlslab = 'URLSLAB';
 
 		$this->load_dependencies();
@@ -98,16 +97,15 @@ class Urlslab
 	 *
 	 * gets wp_option for URLSLAB plugin
 	 */
-	public static function get_option($name, $default = false)
-	{
-		$option = get_option('urlslab');
+	public static function get_option( $name, $default = false ) {
+		$option = get_option( 'urlslab' );
 
-		if (false === $option) {
+		if ( false === $option ) {
 			return $default;
 		}
 
-		if (isset($option[$name])) {
-			return $option[$name];
+		if ( isset( $option[ $name ] ) ) {
+			return $option[ $name ];
 		} else {
 			return $default;
 		}
@@ -117,31 +115,29 @@ class Urlslab
 	 *
 	 * updates wp_option for URLSLAB plugin
 	 */
-	public static function update_option($name, $value)
-	{
-		$option = get_option('urlslab');
-		$option = (false === $option) ? array() : (array)$option;
-		$option = array_merge($option, array($name => $value));
-		update_option('urlslab', $option);
+	public static function update_option( $name, $value ) {
+		$option = get_option( 'urlslab' );
+		$option = ( false === $option ) ? array() : (array) $option;
+		$option = array_merge( $option, array( $name => $value ) );
+		update_option( 'urlslab', $option );
 	}
 
 
-	public function init_urlslab_user()
-	{
-		$api_key = $this->get_option('api-key');
+	public function init_urlslab_user() {
+		$api_key = $this->get_option( 'api-key' );
 		$urlslab_user_widget = Urlslab_User_Widget::get_instance();
 		$urlslab_available_widgets = Urlslab_Available_Widgets::get_instance();
 
-		if (!empty($api_key)) {
+		if ( ! empty( $api_key ) ) {
 			$urlslab_user_widget->add_api_key(
-				new Urlslab_Api_Key($api_key)
+				new Urlslab_Api_Key( $api_key )
 			);
 		}
-		$urlslab_api = new Urlslab_Api_Key($api_key);
+		$urlslab_api = new Urlslab_Api_Key( $api_key );
 		$this->url_data_fetcher = new Urlslab_Url_Data_Fetcher(
-			new Urlslab_Screenshot_Api($urlslab_api)
+			new Urlslab_Screenshot_Api( $urlslab_api )
 		);
-		$urlslab_available_widgets->init_widgets($this->url_data_fetcher);
+		$urlslab_available_widgets->init_widgets( $this->url_data_fetcher );
 	}
 
 	/**
@@ -160,31 +156,29 @@ class Urlslab
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function load_dependencies()
-	{
-
+	private function load_dependencies() { 
 		/**
 		 * The class responsible for orchestrating the actions and filters of the
 		 * core plugin.
 		 */
-		require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-urlslab-loader.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-urlslab-loader.php';
 
 		/**
 		 * The class responsible for defining internationalization functionality
 		 * of the plugin.
 		 */
-		require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-urlslab-i18n.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-urlslab-i18n.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
-		require_once plugin_dir_path(dirname(__FILE__)) . 'admin/class-urlslab-admin.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-urlslab-admin.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */
-		require_once plugin_dir_path(dirname(__FILE__)) . 'public/class-urlslab-public.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-urlslab-public.php';
 
 		$this->loader = new Urlslab_Loader();
 
@@ -199,12 +193,10 @@ class Urlslab
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function set_locale()
-	{
-
+	private function set_locale() { 
 		$plugin_i18n = new Urlslab_I18n();
 
-		$this->loader->add_action('plugins_loaded', $plugin_i18n, 'load_plugin_textdomain');
+		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
 
 	}
 
@@ -215,15 +207,13 @@ class Urlslab
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function define_admin_hooks()
-	{
+	private function define_admin_hooks() { 
+		$plugin_admin = new Urlslab_Admin( $this->get_urlslab(), $this->get_version() );
 
-		$plugin_admin = new Urlslab_Admin($this->get_urlslab(), $this->get_version());
-
-		$this->loader->add_action('admin_init', $this, 'urlslab_upgrade', 10, 0);
-		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
-		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts');
-		$this->loader->add_action('admin_menu', $plugin_admin, 'urlslab_admin_menu', 9, 0);
+		$this->loader->add_action( 'admin_init', $this, 'urlslab_upgrade', 10, 0 );
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+		$this->loader->add_action( 'admin_menu', $plugin_admin, 'urlslab_admin_menu', 9, 0 );
 		$this->loader->add_action(
 			'wp_loaded',
 			$plugin_admin,
@@ -241,66 +231,60 @@ class Urlslab
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function define_public_hooks()
-	{
+	private function define_public_hooks() { 
+		$plugin_public = new Urlslab_Public( $this->get_urlslab(), $this->get_version() );
 
-		$plugin_public = new Urlslab_Public($this->get_urlslab(), $this->get_version());
-
-		$this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_styles');
-		$this->loader->add_action('wp_enqueue_scripts', $plugin_public, 'enqueue_scripts');
-		$this->add_public_content_filters($plugin_public);
+		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+		$this->add_public_content_filters( $plugin_public );
 	}
 
-	private function add_public_content_filters(Urlslab_Public $plugin_public)
-	{
+	private function add_public_content_filters( Urlslab_Public $plugin_public ) {
 		//TODO - this should activate the widgets according to user settings Urlslab_User_Widget
 		//# The order of adding add_filter is important, since no priority is used in filters
 		//# Order Group 1
-		$this->loader->add_filter('the_content', $plugin_public, 'the_content_keywords_links');
-		$this->loader->add_filter('the_content', $plugin_public, 'the_content_link_enhancer');
-		$this->loader->add_filter('the_content', $plugin_public, 'the_content_image_alt_attribute');
+		$this->loader->add_filter( 'the_content', $plugin_public, 'the_content_keywords_links' );
+		$this->loader->add_filter( 'the_content', $plugin_public, 'the_content_link_enhancer' );
+		$this->loader->add_filter( 'the_content', $plugin_public, 'the_content_image_alt_attribute' );
 		//# Order Group 1
 
 		//# Order Group 2
-		$this->loader->add_action('wp_head', $plugin_public, 'the_content_og_meta_tag');
+		$this->loader->add_action( 'wp_head', $plugin_public, 'the_content_og_meta_tag' );
 		//# Order Group 2
 	}
 
-	private function define_backend_hooks()
-	{
+	private function define_backend_hooks() {
 		//defining Upgrade hook
 		require_once URLSLAB_PLUGIN_DIR . '/includes/cron/class-urlslab-screenshot-cron.php';
-		$cron_job = new Urlslab_Screenshot_Cron($this->url_data_fetcher);
+		$cron_job = new Urlslab_Screenshot_Cron( $this->url_data_fetcher );
 
-		$this->loader->add_action('init', $this, 'urlslab_shortcodes_init', 10, 0);
-		$this->loader->add_action('urlslab_cron_hook', $cron_job, 'urlslab_cron_exec', 10, 0);
-		if (!wp_next_scheduled('urlslab_cron_hook')) {
-			wp_schedule_event(time(), 'every_minute', 'urlslab_cron_hook');
+		$this->loader->add_action( 'init', $this, 'urlslab_shortcodes_init', 10, 0 );
+		$this->loader->add_action( 'urlslab_cron_hook', $cron_job, 'urlslab_cron_exec', 10, 0 );
+		if ( ! wp_next_scheduled( 'urlslab_cron_hook' ) ) {
+			wp_schedule_event( time(), 'every_minute', 'urlslab_cron_hook' );
 		}
 	}
 
 
-	public function urlslab_shortcodes_init()
-	{
-		foreach (Urlslab_Available_Widgets::get_instance()->get_all_widgets() as $i => $widget) {
-			add_shortcode($widget->get_widget_slug(), array($widget, 'get_shortcode_content'));
+	public function urlslab_shortcodes_init() {
+		foreach ( Urlslab_Available_Widgets::get_instance()->get_all_widgets() as $i => $widget ) {
+			add_shortcode( $widget->get_widget_slug(), array( $widget, 'get_shortcode_content' ) );
 		}
 	}
 
 	/**
 	 * Upgrades option data when necessary.
 	 */
-	public function urlslab_upgrade()
-	{
-		$old_ver = $this->get_option('version', '0');
+	public function urlslab_upgrade() {
+		 $old_ver = $this->get_option( 'version', '0' );
 		$new_ver = URLSLAB_VERSION;
 
-		if ($old_ver == $new_ver) {
+		if ( $old_ver == $new_ver ) {
 			return;
 		}
 		// Any Upgrade hook should be done here. For now no Upgrade migration is available
 
-		$this->update_option('version', $new_ver);
+		$this->update_option( 'version', $new_ver );
 	}
 
 	/**
@@ -308,9 +292,8 @@ class Urlslab
 	 *
 	 * @since    1.0.0
 	 */
-	public function run()
-	{
-		$this->loader->run();
+	public function run() {
+		 $this->loader->run();
 	}
 
 	/**
@@ -320,8 +303,7 @@ class Urlslab
 	 * @return    string    The name of the plugin.
 	 * @since     1.0.0
 	 */
-	public function get_urlslab(): string
-	{
+	public function get_urlslab(): string {
 		return $this->urlslab;
 	}
 
@@ -331,8 +313,7 @@ class Urlslab
 	 * @return    Urlslab_Loader    Orchestrates the hooks of the plugin.
 	 * @since     1.0.0
 	 */
-	public function get_loader(): Urlslab_Loader
-	{
+	public function get_loader(): Urlslab_Loader {
 		return $this->loader;
 	}
 
@@ -342,8 +323,7 @@ class Urlslab
 	 * @return    string    The version number of the plugin.
 	 * @since     1.0.0
 	 */
-	public function get_version(): string
-	{
+	public function get_version(): string {
 		return $this->version;
 	}
 

--- a/includes/widgets/class-urlslab-image-alt-text.php
+++ b/includes/widgets/class-urlslab-image-alt-text.php
@@ -5,8 +5,8 @@ require_once URLSLAB_PLUGIN_DIR . '/includes/widgets/class-urlslab-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-user-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-url.php';
 
-class Urlslab_Image_Alt_Text extends Urlslab_Widget
-{
+class Urlslab_Image_Alt_Text extends Urlslab_Widget {
+
 	private string $widget_slug = 'urlslab-image-alt-attribute';
 
 	private string $widget_title = 'Image Alt Attributes';
@@ -21,96 +21,87 @@ class Urlslab_Image_Alt_Text extends Urlslab_Widget
 	/**
 	 * @return string
 	 */
-	public function get_widget_slug(): string
-	{
+	public function get_widget_slug(): string {
 		return $this->widget_slug;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_title(): string
-	{
+	public function get_widget_title(): string {
 		return 'Urlslab ' . $this->widget_title;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_description(): string
-	{
+	public function get_widget_description(): string {
 		return $this->widget_description;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_landing_page_link(): string
-	{
+	public function get_landing_page_link(): string {
 		return $this->landing_page_link;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_slug(): string
-	{
+	public function get_admin_menu_page_slug(): string {
 		return URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_url(): string
-	{
+	public function get_admin_menu_page_url(): string {
 		//TODO - implement for the admin page of plugin
-		return $this->menu_page_url(URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php');
+		return $this->menu_page_url( URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php' );
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_title(): string
-	{
+	public function get_admin_menu_page_title(): string {
 		return 'Urlslab Widget | Image Alt Attributes';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_title(): string
-	{
+	public function get_admin_menu_title(): string {
 		return 'Image Alt Attributes';
 	}
 
-	public function theContentHook($content)
-	{
-		if (trim($content) === '') {
+	public function theContentHook( $content) {
+		if (trim( $content ) === '') {
 			return $content;    //nothing to process
 		}
 
 		$document = new DOMDocument();
-		$document->encoding = get_bloginfo('charset');
+		$document->encoding = get_bloginfo( 'charset' );
 		$document->strictErrorChecking = false; // phpcs:ignore
-		$libxml_previous_state = libxml_use_internal_errors(true);
+		$libxml_previous_state = libxml_use_internal_errors( true );
 		try {
-			$document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+			$document->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			libxml_clear_errors();
-			libxml_use_internal_errors($libxml_previous_state);
+			libxml_use_internal_errors( $libxml_previous_state );
 
-			$xpath = new DOMXPath($document);
-			$table_data = $xpath->query("//img[not(@alt) or @alt='']|//*[starts-with(name(),'h')]");
+			$xpath = new DOMXPath( $document );
+			$table_data = $xpath->query( "//img[not(@alt) or @alt='']|//*[starts-with(name(),'h')]" );
 			$title = '';
 
-			if (!empty($table_data)) {
+			if (!empty( $table_data )) {
 				foreach ($table_data as $element) {
-					if (substr($element->nodeName, 0, 1) == 'h') {
+					if (substr( $element->nodeName, 0, 1 ) == 'h') {
 						$title = $element->nodeValue;
 					} elseif ('img' == $element->nodeName) {
-						if (isset($element->parentNode) && $element->parentNode->nodeName == 'a' && $element->parentNode->hasAttribute('title')) {
-							$element->setAttribute('alt', $title . ' - ' . $element->parentNode->getAttribute('title'));
-						} elseif (strlen($title)) {
-							$element->setAttribute('alt', $title);
+						if (isset( $element->parentNode ) && $element->parentNode->nodeName == 'a' && $element->parentNode->hasAttribute( 'title' )) {
+							$element->setAttribute( 'alt', $title . ' - ' . $element->parentNode->getAttribute( 'title' ) );
+						} elseif (strlen( $title )) {
+							$element->setAttribute( 'alt', $title );
 						}
 					}
 				}
@@ -119,17 +110,15 @@ class Urlslab_Image_Alt_Text extends Urlslab_Widget
 			}
 			return $document->saveHTML();
 		} catch (Exception $e) {
-			return $content . "\n" . "<!---\n Error:" . esc_html($e->getMessage()) . "\n--->";
+			return $content . "\n" . "<!---\n Error:" . esc_html( $e->getMessage() ) . "\n--->";
 		}
 	}
 
-	public function get_shortcode_content($atts = array(), $content = null, $tag = ''): string
-	{
+	public function get_shortcode_content( $atts = array(), $content = null, $tag = ''): string {
 		return '';
 	}
 
-	public function has_shortcode(): bool
-	{
+	public function has_shortcode(): bool {
 		return false;
 	}
 }

--- a/includes/widgets/class-urlslab-keywords-links.php
+++ b/includes/widgets/class-urlslab-keywords-links.php
@@ -5,8 +5,8 @@ require_once URLSLAB_PLUGIN_DIR . '/includes/widgets/class-urlslab-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-user-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-url.php';
 
-class Urlslab_Keywords_Links extends Urlslab_Widget
-{
+class Urlslab_Keywords_Links extends Urlslab_Widget {
+
 	private string $widget_slug = 'urlslab-keywords-links';
 
 	private string $widget_title = 'Keywords Links';
@@ -37,61 +37,53 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 	/**
 	 * @return string
 	 */
-	public function get_widget_slug(): string
-	{
+	public function get_widget_slug(): string {
 		return $this->widget_slug;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_title(): string
-	{
+	public function get_widget_title(): string {
 		return 'Urlslab ' . $this->widget_title;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_description(): string
-	{
+	public function get_widget_description(): string {
 		return $this->widget_description;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_landing_page_link(): string
-	{
+	public function get_landing_page_link(): string {
 		return $this->landing_page_link;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_slug(): string
-	{
+	public function get_admin_menu_page_slug(): string {
 		return URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_title(): string
-	{
+	public function get_admin_menu_page_title(): string {
 		return 'Urlslab Widget | Keywords Links';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_title(): string
-	{
+	public function get_admin_menu_title(): string {
 		return 'Keywords Links';
 	}
 
-	private function replaceKeywordWithLinks(DOMText $node, DOMDocument $document, array $keywords)
-	{
+	private function replaceKeywordWithLinks( DOMText $node, DOMDocument $document, array $keywords) {
 		//TODO: load all limits from widget settings and not from constants, use constants later just like default value of settings
 		if ($this->cnt_page_links > self::MAX_LINKS_ON_PAGE ||
 			$this->cnt_page_link_replacements > self::MAX_REPLACEMENTS_PER_PAGE ||
@@ -99,22 +91,22 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 			return;
 		}
 
-		if (0 == strlen(trim($node->nodeValue))) {
+		if (0 == strlen( trim( $node->nodeValue ) )) {
 			return; //empty node
 		}
 
 		foreach ($keywords as $kw => $url) {
-			if (preg_match('/\b(' . preg_quote(strtolower($kw), '/') . ')\b/', strtolower($node->nodeValue), $matches, PREG_OFFSET_CAPTURE)) {
+			if (preg_match( '/\b(' . preg_quote( strtolower( $kw ), '/' ) . ')\b/', strtolower( $node->nodeValue ), $matches, PREG_OFFSET_CAPTURE )) {
 				$pos = $matches[1][1];
 				$this->cnt_page_links++;
 				$this->cnt_page_link_replacements++;
 				$this->cnt_paragraph_link_replacements++;
-				if (isset($this->kw_page_replacement_counts[$kw])) {
+				if (isset( $this->kw_page_replacement_counts[$kw] )) {
 					$this->kw_page_replacement_counts[$kw]++;
 				} else {
 					$this->kw_page_replacement_counts[$kw] = 1;
 				}
-				if (isset($this->url_page_replacement_counts[$url])) {
+				if (isset( $this->url_page_replacement_counts[$url] )) {
 					$this->url_page_replacement_counts[$url]++;
 				} else {
 					$this->url_page_replacement_counts[$url] = 1;
@@ -122,7 +114,7 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 
 				//if we reached maximum number of replacements with this kw, skip next processing
 				if ($this->kw_page_replacement_counts[$kw] > self::MAX_REPLACEMENTS_PER_KEYWORD) {
-					unset($keywords[$kw]);
+					unset( $keywords[$kw] );
 					return;
 				}
 
@@ -130,7 +122,7 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 				if ($this->url_page_replacement_counts[$url] > self::MAX_REPLACEMENTS_PER_URL) {
 					foreach ($keywords as $k => $u) {
 						if ($u == $url) {
-							unset($keywords[$k]);
+							unset( $keywords[$k] );
 						}
 					}
 					return;
@@ -139,7 +131,7 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 				//add text before keyword
 				if ($pos > 0) {
 					$domTextStart = $document->createTextNode(substr($node->nodeValue, 0, $pos)); // phpcs:ignore
-					$node->parentNode->insertBefore($domTextStart, $node);
+					$node->parentNode->insertBefore( $domTextStart, $node );
 				} else {
 					$domTextStart = null;
 				}
@@ -147,45 +139,44 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 				//add keyword as link
 				$linkDom = $document->createElement(
 					'a',
-					substr($node->nodeValue, $pos, strlen($kw))
+					substr( $node->nodeValue, $pos, strlen( $kw ) )
 				);
-				$linkDom->setAttribute('href', $url);
+				$linkDom->setAttribute( 'href', $url );
 
 				//if relative url or url from same domain, don't add target attribute
-				if (!urlslab_is_same_domain_url($url)) {
-					$linkDom->setAttribute('target', '_blank');
+				if (!urlslab_is_same_domain_url( $url )) {
+					$linkDom->setAttribute( 'target', '_blank' );
 				}
 
-				$node->parentNode->insertBefore($linkDom, $node);
+				$node->parentNode->insertBefore( $linkDom, $node );
 
 				//add text after keyword
-				if ($pos + strlen($kw) < strlen($node->nodeValue)) {
-					$domTextEnd = $document->createTextNode(substr($node->nodeValue, $pos + strlen($kw)));
-					$node->parentNode->insertBefore($domTextEnd, $node);
+				if ($pos + strlen( $kw ) < strlen( $node->nodeValue )) {
+					$domTextEnd = $document->createTextNode( substr( $node->nodeValue, $pos + strlen( $kw ) ) );
+					$node->parentNode->insertBefore( $domTextEnd, $node );
 				} else {
 					$domTextEnd = null;
 				}
 
 				//process other keywords in text
-				if (is_object($domTextStart)) {
-					$this->replaceKeywordWithLinks($domTextStart, $document, $keywords);
+				if (is_object( $domTextStart )) {
+					$this->replaceKeywordWithLinks( $domTextStart, $document, $keywords );
 				}
-				if (is_object($domTextEnd)) {
-					$this->replaceKeywordWithLinks($domTextEnd, $document, $keywords);
+				if (is_object( $domTextEnd )) {
+					$this->replaceKeywordWithLinks( $domTextEnd, $document, $keywords );
 				}
 
 				//remove processed node
-				$node->parentNode->removeChild($node);
+				$node->parentNode->removeChild( $node );
 
 				return;
 			}
-			unset($keywords[$kw]);
+			unset( $keywords[$kw] );
 		}
 	}
 
-	private function get_keywords()
-	{
-		if (empty($this->keywords_cache)) {
+	private function get_keywords() {
+		if (empty( $this->keywords_cache )) {
 			global $wpdb;
 
 			$keyword_table = $wpdb->prefix . 'urlslab_keyword_widget';
@@ -208,8 +199,8 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 
 		$keywords = array();
 		foreach ($this->keywords_cache as $kw => $lnk) {
-			if ((!isset($this->kw_page_replacement_counts[$kw]) || $this->kw_page_replacement_counts[$kw] < self::MAX_REPLACEMENTS_PER_KEYWORD) &&
-				(!isset($this->url_page_replacement_counts[$lnk]) || $this->url_page_replacement_counts[$lnk] < self::MAX_REPLACEMENTS_PER_URL)) {
+			if (( !isset( $this->kw_page_replacement_counts[$kw] ) || $this->kw_page_replacement_counts[$kw] < self::MAX_REPLACEMENTS_PER_KEYWORD ) &&
+				( !isset( $this->url_page_replacement_counts[$lnk] ) || $this->url_page_replacement_counts[$lnk] < self::MAX_REPLACEMENTS_PER_URL )) {
 				$keywords[$kw] = $lnk;
 			}
 		}
@@ -217,71 +208,68 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 		return $keywords;
 	}
 
-	private function findTextDOMElements(DOMNode $dom, DOMDocument $document)
-	{
+	private function findTextDOMElements( DOMNode $dom, DOMDocument $document) {
 		//skip processing if HTML tag contains attribute "urlslab-skip"
-		if ($dom->hasAttributes() && $dom->hasAttribute('urlslab-skip')) {
+		if ($dom->hasAttributes() && $dom->hasAttribute( 'urlslab-skip' )) {
 			return;
 		}
 
-		if (!empty($dom->childNodes)) {
+		if (!empty( $dom->childNodes )) {
 			foreach ($dom->childNodes as $node) {
 
-				if ($node instanceof DOMText && strlen(trim($node->nodeValue)) > 1) {
-					$this->replaceKeywordWithLinks($node, $document, $this->get_keywords());
+				if ($node instanceof DOMText && strlen( trim( $node->nodeValue ) ) > 1) {
+					$this->replaceKeywordWithLinks( $node, $document, $this->get_keywords() );
 				} else {
-					if (count($this->link_counts) > 0 && preg_match('/^[hH][0-9]$/', $node->nodeName)) {
-						$this->cnt_paragraph_link_replacements = array_shift($this->link_counts);
+					if (count( $this->link_counts ) > 0 && preg_match( '/^[hH][0-9]$/', $node->nodeName )) {
+						$this->cnt_paragraph_link_replacements = array_shift( $this->link_counts );
 					}
 
 					//skip processing some types of HTML elements
-					if (!in_array(strtolower($node->nodeName), array('a', 'button', 'input')) &&
-						!preg_match('/^[hH][0-9]$/', $node->nodeName)) {
-						$this->findTextDOMElements($node, $document);
+					if (!in_array( strtolower( $node->nodeName ), array('a', 'button', 'input') ) &&
+						!preg_match( '/^[hH][0-9]$/', $node->nodeName )) {
+						$this->findTextDOMElements( $node, $document );
 					}
 				}
 			}
 		}
 	}
 
-	public function theContentHook($content)
-	{
-		if (!strlen(trim($content))) {
+	public function theContentHook( $content) {
+		if (!strlen( trim( $content ) )) {
 			return $content;    //nothing to process
 		}
 
 		$document = new DOMDocument();
-		$document->encoding = get_bloginfo('charset');
+		$document->encoding = get_bloginfo( 'charset' );
 		$document->strictErrorChecking = false;
-		$libxml_previous_state = libxml_use_internal_errors(true);
+		$libxml_previous_state = libxml_use_internal_errors( true );
 		try {
-			$document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+			$document->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			libxml_clear_errors();
-			libxml_use_internal_errors($libxml_previous_state);
+			libxml_use_internal_errors( $libxml_previous_state );
 
-			$this->initLinkCounts($document);
+			$this->initLinkCounts( $document );
 			if ($this->cnt_page_links > self::MAX_LINKS_ON_PAGE) {
 				return $content;
 			}
 
-			$this->findTextDOMElements($document, $document);
+			$this->findTextDOMElements( $document, $document );
 
 			return $document->saveHTML();
 		} catch (Exception $e) {
-			return $content . "\n" . "<!---\n Error:" . esc_html($e->getMessage()) . "\n--->";
+			return $content . "\n" . "<!---\n Error:" . esc_html( $e->getMessage() ) . "\n--->";
 		}
 	}
 
-	private function initLinkCounts(DOMDocument $document)
-	{
+	private function initLinkCounts( DOMDocument $document) {
 		$this->cnt_page_link_replacements = 0;
 		$this->cnt_page_links = 0;
 		$this->kw_page_replacement_counts = array();
 		$this->url_page_replacement_counts = array();
 		$this->link_counts = array();
 		$cnt = 0;
-		$xpath = new DOMXPath($document);
-		$table_data = $xpath->query("//a|//*[starts-with(name(),'h')]");
+		$xpath = new DOMXPath( $document );
+		$table_data = $xpath->query( "//a|//*[starts-with(name(),'h')]" );
 		$hasLinksBeforeH1 = false;
 		$hadHAlready = false;
 		foreach ($table_data as $element) {
@@ -292,7 +280,7 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 				$this->cnt_page_links++;
 				$cnt++;
 			}
-			if (substr($element->nodeName, 0, 1) == 'h') {
+			if (substr( $element->nodeName, 0, 1 ) == 'h') {
 				$hadHAlready = true;
 				$this->link_counts[] = $cnt;
 				$cnt = 0;
@@ -301,17 +289,15 @@ class Urlslab_Keywords_Links extends Urlslab_Widget
 		$this->link_counts[] = $cnt;
 
 		if ($hasLinksBeforeH1) {
-			$this->cnt_paragraph_link_replacements = array_shift($this->link_counts);
+			$this->cnt_paragraph_link_replacements = array_shift( $this->link_counts );
 		}
 	}
 
-	public function get_shortcode_content($atts = array(), $content = null, $tag = ''): string
-	{
+	public function get_shortcode_content( $atts = array(), $content = null, $tag = ''): string {
 		return '';
 	}
 
-	public function has_shortcode(): bool
-	{
+	public function has_shortcode(): bool {
 		return false;
 	}
 }

--- a/includes/widgets/class-urlslab-link-enhancer.php
+++ b/includes/widgets/class-urlslab-link-enhancer.php
@@ -5,8 +5,8 @@ require_once URLSLAB_PLUGIN_DIR . '/includes/widgets/class-urlslab-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-user-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-url.php';
 
-class Urlslab_Link_Enhancer extends Urlslab_Widget
-{
+class Urlslab_Link_Enhancer extends Urlslab_Widget {
+
 	private string $widget_slug = 'urlslab-link-enhancer';
 
 	private string $widget_title = 'Link Enhancer';
@@ -22,8 +22,7 @@ class Urlslab_Link_Enhancer extends Urlslab_Widget
 	/**
 	 * @param Urlslab_Url_Data_Fetcher $urlslab_url_data_fetcher
 	 */
-	public function __construct(Urlslab_Url_Data_Fetcher $urlslab_url_data_fetcher)
-	{
+	public function __construct( Urlslab_Url_Data_Fetcher $urlslab_url_data_fetcher) {
 		$this->urlslab_url_data_fetcher = $urlslab_url_data_fetcher;
 	}
 
@@ -31,102 +30,94 @@ class Urlslab_Link_Enhancer extends Urlslab_Widget
 	/**
 	 * @return string
 	 */
-	public function get_widget_slug(): string
-	{
+	public function get_widget_slug(): string {
 		return $this->widget_slug;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_title(): string
-	{
+	public function get_widget_title(): string {
 		return 'Urlslab ' . $this->widget_title;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_description(): string
-	{
+	public function get_widget_description(): string {
 		return $this->widget_description;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_landing_page_link(): string
-	{
+	public function get_landing_page_link(): string {
 		return $this->landing_page_link;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_slug(): string
-	{
+	public function get_admin_menu_page_slug(): string {
 		return URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_title(): string
-	{
+	public function get_admin_menu_page_title(): string {
 		return 'Urlslab Widget | Link Enhancer';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_title(): string
-	{
+	public function get_admin_menu_title(): string {
 		return 'Link Enhancer';
 	}
 
-	public function theContentHook($content)
-	{
-		if (trim($content) === '') {
+	public function theContentHook( $content) {
+		if (trim( $content ) === '') {
 			return $content;    //nothing to process
 		}
 
 		$document = new DOMDocument();
-		$document->encoding = get_bloginfo('charset');
+		$document->encoding = get_bloginfo( 'charset' );
 		$document->strictErrorChecking = false;
-		$libxml_previous_state = libxml_use_internal_errors(true);
+		$libxml_previous_state = libxml_use_internal_errors( true );
 		try {
-			$document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+			$document->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			libxml_clear_errors();
-			libxml_use_internal_errors($libxml_previous_state);
+			libxml_use_internal_errors( $libxml_previous_state );
 
-			$elements = $document->getElementsByTagName('a');
+			$elements = $document->getElementsByTagName( 'a' );
 
 			$elements_to_enhance = array();
 			if ($elements instanceof DOMNodeList) {
 				foreach ($elements as $dom_element) {
 					//skip processing if A tag contains attribute "urlslab-skip"
-					if ($dom_element->hasAttribute('urlslab-skip')) {
+					if ($dom_element->hasAttribute( 'urlslab-skip' )) {
 						continue;
 					}
 
-					if ($dom_element->getAttribute('title') == '' && $dom_element->getAttribute('href') != '') {
-						$url = new Urlslab_Url($dom_element->getAttribute('href'));
+					if ($dom_element->getAttribute( 'title' ) == '' && $dom_element->getAttribute( 'href' ) != '') {
+						$url = new Urlslab_Url( $dom_element->getAttribute( 'href' ) );
 						$elements_to_enhance[] = array($dom_element, $url);
 					}
 				}
 			}
 
-			if (!empty($elements_to_enhance)) {
+			if (!empty( $elements_to_enhance )) {
 
 				$result = $this->urlslab_url_data_fetcher->fetch_schedule_urls_batch(
-					array_map(fn($elem): Urlslab_Url => $elem[1], $elements_to_enhance)
+					array_map( fn( $elem): Urlslab_Url => $elem[1], $elements_to_enhance )
 				);
 
-				if (!empty($result)) {
+				if (!empty( $result )) {
 					foreach ($elements_to_enhance as $arr_element) {
-						if (isset($result[$arr_element[1]->get_url_id()]) &&
-							!empty($result[$arr_element[1]->get_url_id()])) {
-							($arr_element[0])->setAttribute(
+						if (isset( $result[$arr_element[1]->get_url_id()] ) &&
+							!empty( $result[$arr_element[1]->get_url_id()] )) {
+							( $arr_element[0] )->setAttribute(
 								'title',
 								$result[$arr_element[1]->get_url_id()]->get_url_summary_text(),
 							);
@@ -137,17 +128,15 @@ class Urlslab_Link_Enhancer extends Urlslab_Widget
 
 			return $document->saveHTML();
 		} catch (Exception $e) {
-			return $content . "\n" . "<!---\n Error:" . str_replace('>', ' ', $e->getMessage()) . "\n--->";
+			return $content . "\n" . "<!---\n Error:" . str_replace( '>', ' ', $e->getMessage() ) . "\n--->";
 		}
 	}
 
-	public function get_shortcode_content($atts = array(), $content = null, $tag = ''): string
-	{
+	public function get_shortcode_content( $atts = array(), $content = null, $tag = ''): string {
 		return '';
 	}
 
-	public function has_shortcode(): bool
-	{
+	public function has_shortcode(): bool {
 		return false;
 	}
 }

--- a/includes/widgets/class-urlslab-og-meta-tag.php
+++ b/includes/widgets/class-urlslab-og-meta-tag.php
@@ -5,8 +5,8 @@ require_once URLSLAB_PLUGIN_DIR . '/includes/widgets/class-urlslab-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-user-widget.php';
 require_once URLSLAB_PLUGIN_DIR . '/includes/class-urlslab-url.php';
 
-class Urlslab_Og_Meta_Tag extends Urlslab_Widget
-{
+class Urlslab_Og_Meta_Tag extends Urlslab_Widget {
+
 	private string $widget_slug = 'urlslab-og-meta-tag';
 
 	private string $widget_title = 'OG Meta Tag';
@@ -20,8 +20,7 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 	/**
 	 * @param Urlslab_Url_Data_Fetcher $url_data_fetcher
 	 */
-	public function __construct(Urlslab_Url_Data_Fetcher $url_data_fetcher)
-	{
+	public function __construct( Urlslab_Url_Data_Fetcher $url_data_fetcher) {
 		$this->url_data_fetcher = $url_data_fetcher;
 	}
 
@@ -29,88 +28,79 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 	/**
 	 * @return string
 	 */
-	public function get_widget_slug(): string
-	{
+	public function get_widget_slug(): string {
 		return $this->widget_slug;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_title(): string
-	{
+	public function get_widget_title(): string {
 		return 'Urlslab ' . $this->widget_title;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_widget_description(): string
-	{
+	public function get_widget_description(): string {
 		return $this->widget_description;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_landing_page_link(): string
-	{
+	public function get_landing_page_link(): string {
 		return $this->landing_page_link;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_slug(): string
-	{
+	public function get_admin_menu_page_slug(): string {
 		return URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_url(): string
-	{
+	public function get_admin_menu_page_url(): string {
 		//TODO - implement for the admin page of plugin
-		return $this->menu_page_url(URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php');
+		return $this->menu_page_url( URLSLAB_PLUGIN_DIR . '/admin/partials/urlslab-admin-screenshot-display.php' );
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_page_title(): string
-	{
+	public function get_admin_menu_page_title(): string {
 		return 'Urlslab Widget | og Meta Tag';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_admin_menu_title(): string
-	{
+	public function get_admin_menu_title(): string {
 		return 'Og Meta tag';
 	}
 
-	public function theContentHook($content)
-	{
-		if (!strlen(trim($content))) {
+	public function theContentHook( $content) {
+		if (!strlen( trim( $content ) )) {
 			return $content;    //nothing to process
 		}
 
 		$document = new DOMDocument();
-		$document->encoding = get_bloginfo('charset');
+		$document->encoding = get_bloginfo( 'charset' );
 		$document->strictErrorChecking = false;
-		$libxml_previous_state = libxml_use_internal_errors(true);
+		$libxml_previous_state = libxml_use_internal_errors( true );
 		try {
-			$document->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+			$document->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			libxml_clear_errors();
-			libxml_use_internal_errors($libxml_previous_state);
+			libxml_use_internal_errors( $libxml_previous_state );
 
-			$xpath = new DOMXPath($document);
-			$meta_description = $xpath->query("//meta[@name='description']");
-			$meta_og_title = $xpath->query("//meta[@property='og:title']");
-			$meta_og_image = $xpath->query("//meta[@property='og:image']");
-			$meta_og_description = $xpath->query("//meta[@property='og:description']");
+			$xpath = new DOMXPath( $document );
+			$meta_description = $xpath->query( "//meta[@name='description']" );
+			$meta_og_title = $xpath->query( "//meta[@property='og:title']" );
+			$meta_og_image = $xpath->query( "//meta[@property='og:image']" );
+			$meta_og_description = $xpath->query( "//meta[@property='og:description']" );
 
 			$url_data = null;
 			if ($meta_description->count() == 0 ||
@@ -121,17 +111,17 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 					get_current_page_url()
 				);
 
-				if (!is_null($url_data)) {
+				if (!is_null( $url_data )) {
 					// meta description generation
 					if ($meta_description->count() == 0) {
-						$node = $document->createElement('meta');
-						$node->setAttribute('name', 'description');
-						$node->setAttribute('content', $url_data->get_url_summary_text());
-						$document->appendChild($node);
+						$node = $document->createElement( 'meta' );
+						$node->setAttribute( 'name', 'description' );
+						$node->setAttribute( 'content', $url_data->get_url_summary_text() );
+						$document->appendChild( $node );
 					} else {
 						foreach ($meta_description as $node) {
-							if (strlen(trim($node->getAttribute('content'))) < 3) {
-								$node->setAttribute('content', $url_data->get_url_summary_text());
+							if (strlen( trim( $node->getAttribute( 'content' ) ) ) < 3) {
+								$node->setAttribute( 'content', $url_data->get_url_summary_text() );
 							}
 						}
 					}
@@ -141,14 +131,14 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 
 					// meta og title generation
 					if ($meta_og_title->count() == 0) {
-						$node = $document->createElement('meta');
-						$node->setAttribute('property', 'og:title');
-						$node->setAttribute('content', $url_data->get_url_summary_text());
-						$document->appendChild($node);
+						$node = $document->createElement( 'meta' );
+						$node->setAttribute( 'property', 'og:title' );
+						$node->setAttribute( 'content', $url_data->get_url_summary_text() );
+						$document->appendChild( $node );
 					} else {
 						foreach ($meta_og_title as $node) {
-							if (strlen(trim($node->getAttribute('content'))) < 3) {
-								$node->setAttribute('content', $url_data->get_url_summary_text());
+							if (strlen( trim( $node->getAttribute( 'content' ) ) ) < 3) {
+								$node->setAttribute( 'content', $url_data->get_url_summary_text() );
 							}
 						}
 					}
@@ -156,14 +146,14 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 
 					// meta og description generation
 					if ($meta_og_description->count() == 0) {
-						$node = $document->createElement('meta');
-						$node->setAttribute('property', 'og:description');
-						$node->setAttribute('content', $url_data->get_url_summary_text());
-						$document->appendChild($node);
+						$node = $document->createElement( 'meta' );
+						$node->setAttribute( 'property', 'og:description' );
+						$node->setAttribute( 'content', $url_data->get_url_summary_text() );
+						$document->appendChild( $node );
 					} else {
 						foreach ($meta_og_description as $node) {
-							if (strlen(trim($node->getAttribute('content'))) < 3) {
-								$node->setAttribute('content', $url_data->get_url_summary_text());
+							if (strlen( trim( $node->getAttribute( 'content' ) ) ) < 3) {
+								$node->setAttribute( 'content', $url_data->get_url_summary_text() );
 							}
 						}
 					}
@@ -172,14 +162,14 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 					// meta og image generation
 					if ($meta_og_image->count() == 0 &&
 						$url_data->screenshot_exists()) {
-						$node = $document->createElement('meta');
-						$node->setAttribute('property', 'og:image');
-						$node->setAttribute('content', $url_data->render_screenshot_path());
-						$document->appendChild($node);
+						$node = $document->createElement( 'meta' );
+						$node->setAttribute( 'property', 'og:image' );
+						$node->setAttribute( 'content', $url_data->render_screenshot_path() );
+						$document->appendChild( $node );
 					} else {
 						foreach ($meta_og_image as $node) {
-							if (strlen(trim($node->getAttribute('content'))) < 3) {
-								$node->setAttribute('content', $url_data->render_screenshot_path());
+							if (strlen( trim( $node->getAttribute( 'content' ) ) ) < 3) {
+								$node->setAttribute( 'content', $url_data->render_screenshot_path() );
 							}
 						}
 					}
@@ -192,17 +182,15 @@ class Urlslab_Og_Meta_Tag extends Urlslab_Widget
 			return $content;
 
 		} catch (Exception $e) {
-			return $content . "\n" . "<!---\n Error:" . str_replace('>', ' ', $e->getMessage()) . "\n--->";
+			return $content . "\n" . "<!---\n Error:" . str_replace( '>', ' ', $e->getMessage() ) . "\n--->";
 		}
 	}
 
-	public function get_shortcode_content($atts = array(), $content = null, $tag = ''): string
-	{
+	public function get_shortcode_content( $atts = array(), $content = null, $tag = ''): string {
 		return '';
 	}
 
-	public function has_shortcode(): bool
-	{
+	public function has_shortcode(): bool {
 		return false;
 	}
 }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
- characters are converted to html entities before processing by DOMDocument
- load encoding information from wordpress

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues/issues/519
