### PR TITLE
Init title and metadescription from local database

### DIFF
--- a/includes/services/class-urlslab-url-data-fetcher.php
+++ b/includes/services/class-urlslab-url-data-fetcher.php
@@ -215,7 +215,7 @@ or (UNIX_TIMESTAMP(updateStatusDate) + 3600 < %d AND status = %s)
 		$insert_values = array();
 		foreach ( $urls as $url ) {
 			if ( ! isset( $results[ $url->get_url_id() ] ) ) {
-				$url_data = new Urlslab_Url_Data( $url, '', $url->get_url_id(), null, null, null, null, null, Urlslab::$link_status_not_scheduled );
+				$url_data = Urlslab_Url_Data::empty( $url );
 				array_push(
 					$insert_values,
 					$url->get_url_id(),

--- a/includes/services/class-urlslab-url-data.php
+++ b/includes/services/class-urlslab-url-data.php
@@ -36,15 +36,29 @@ class Urlslab_Url_Data {
 					$url_summary,
 					$screenshot_status
 	) {
-		$this->url = $url;
-		$this->domain_id = $domain_id;
-		$this->url_id = $url_id;
-		$this->screenshot_date = $screenshot_date;
+		$this->url                     = $url;
+		$this->domain_id               = $domain_id;
+		$this->url_id                  = $url_id;
+		$this->screenshot_date         = $screenshot_date;
 		$this->last_status_change_date = $last_status_change_date;
-		$this->url_title = $url_title;
-		$this->url_meta_description = $url_meta_description;
-		$this->url_summary = $url_summary;
-		$this->screenshot_status = $screenshot_status;
+		$this->url_title               = $url_title;
+		$this->url_meta_description    = $url_meta_description;
+		$this->url_summary             = $url_summary;
+		$this->screenshot_status       = $screenshot_status;
+	}
+
+	static function empty( Urlslab_Url $url ): Urlslab_Url_Data {
+		return new Urlslab_Url_Data(
+			$url,
+			'',
+			$url->get_url_id(),
+			null,
+			null,
+			null,
+			null,
+			null,
+			Urlslab::$link_status_not_scheduled
+		);
 	}
 
 	/**


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Init title and metadescription from local database

**Testing instructions**
when url is created in database, local urls should have title and description filled in automatically, we don't need to wait for urlslab to fill it in.

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] My commits follow the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues/issues/547