### PR TITLE
feat: use page title text as alt attribute for images before H1 tag

### DIFF
--- a/includes/widgets/class-urlslab-image-alt-text.php
+++ b/includes/widgets/class-urlslab-image-alt-text.php
@@ -91,7 +91,7 @@ class Urlslab_Image_Alt_Text extends Urlslab_Widget {
 
 			$xpath = new DOMXPath( $document );
 			$table_data = $xpath->query( "//img[not(@alt) or @alt='']|//*[starts-with(name(),'h')]" );
-			$title = '';
+			$title = get_the_title();
 
 			if (!empty( $table_data )) {
 				foreach ($table_data as $element) {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
init title variable with page title and not empty string

**Testing instructions**
if image is before the H1, it should have page title as alt text and not empty string

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues/issues/560
