### PR TITLE
feat: convert images to webp and serve them as alternative

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-dom": "*",
-    "aws/aws-sdk-php": "^3.231"
+    "aws/aws-sdk-php": "^3.231",
+    "ext-gd": "*"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fffc2407dbb18730f4b29f082e6a0551",
+    "content-hash": "dc664ddf6f087a8dbd4557caede8f44e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1657,16 +1657,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.4",
+            "version": "v2.11.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "e9c99cda31b21ccb4da4c2124b57c8355ddce48e"
+                "reference": "567221efd5d1ab53260fb76f16c77610454a5d6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/e9c99cda31b21ccb4da4c2124b57c8355ddce48e",
-                "reference": "e9c99cda31b21ccb4da4c2124b57c8355ddce48e",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/567221efd5d1ab53260fb76f16c77610454a5d6a",
+                "reference": "567221efd5d1ab53260fb76f16c77610454a5d6a",
                 "shasum": ""
             },
             "require": {
@@ -1678,7 +1678,8 @@
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
-                "sirbrillig/phpcs-import-detection": "^1.1"
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -1701,7 +1702,7 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
-            "time": "2022-06-13T13:49:41+00:00"
+            "time": "2022-08-13T21:40:42+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1812,7 +1813,8 @@
         "php": ">=7.4",
         "ext-json": "*",
         "ext-libxml": "*",
-        "ext-dom": "*"
+        "ext-dom": "*",
+        "ext-gd": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/includes/class-urlslab-activator.php
+++ b/includes/class-urlslab-activator.php
@@ -66,6 +66,10 @@ class Urlslab_Activator {
 			$wpdb->query('ALTER TABLE ' . URLSLAB_URLS_TABLE . " ADD COLUMN visibility char(1) NOT NULL DEFAULT 'V';"); // phpcs:ignore
 		}
 
+		if ( version_compare( $version, '1.6.0', '<' ) ) {
+			$wpdb->query('ALTER TABLE ' . URLSLAB_FILES_TABLE . " ADD COLUMN webp_fileid char(32), ADD COLUMN use_webp char(1) NOT NULL DEFAULT 'Y', ADD INDEX idx_webp_fileid (webp_fileid, filetype);"); // phpcs:ignore
+		}
+
 		//all update steps done, set the current version
 		update_option( URLSLAB_VERSION_SETTING, URLSLAB_VERSION );
 	}
@@ -167,20 +171,23 @@ class Urlslab_Activator {
 		$table_name = URLSLAB_FILES_TABLE;
 		$charset_collate = $wpdb->get_charset_collate();
 		$sql = "CREATE TABLE IF NOT EXISTS $table_name (
-    		  fileid char(32) NOT NULL,
-			  url varchar(1024) NOT NULL,
-			  local_file varchar(1024),
-			  filename varchar(750),
-			  filesize int(10) UNSIGNED ZEROFILL DEFAULT 0,
-			  filetype varchar(100),
-			  width mediumint(8) UNSIGNED ZEROFILL DEFAULT NULL,
-			  height mediumint(8) UNSIGNED ZEROFILL DEFAULT NULL,
-			  filestatus char(1) NOT NULL,
-			  driver char(1) NOT NULL,
-    		  last_seen datetime NULL,
-			  PRIMARY KEY (fileid),
-			  INDEX idx_file_filter (driver, filestatus),
-			  INDEX idx_file_sort (filesize)
+			fileid char(32) NOT NULL,
+			url varchar(1024) NOT NULL,
+			local_file varchar(1024),
+			filename varchar(750),
+			filesize int(10) UNSIGNED ZEROFILL DEFAULT 0,
+			filetype varchar(100),
+			width mediumint(8) UNSIGNED ZEROFILL DEFAULT NULL,
+			height mediumint(8) UNSIGNED ZEROFILL DEFAULT NULL,
+			filestatus char(1) NOT NULL,
+			driver char(1) NOT NULL,
+			last_seen datetime NULL,
+			webp_fileid char(32) NULL,
+    		use_webp char(1) NOT NULL DEFAULT 'Y'
+			PRIMARY KEY (fileid),
+			INDEX idx_file_filter (driver, filestatus),
+			INDEX idx_file_sort (filesize)
+			INDEX idx_webp_fileid (webp_fileid, filetype)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -324,21 +324,20 @@ class Urlslab {
 		//defining Upgrade hook
 		require_once URLSLAB_PLUGIN_DIR . '/includes/cron/class-urlslab-screenshot-cron.php';
 		$cron_job = new Urlslab_Screenshot_Cron( $this->url_data_fetcher );
-
 		$this->loader->add_action( 'urlslab_cron_hook', $cron_job, 'urlslab_cron_exec', 10, 0 );
+
 		if ( ! wp_next_scheduled( 'urlslab_cron_hook' ) ) {
 			wp_schedule_event( time(), 'every_minute', 'urlslab_cron_hook' );
 		}
 
 		require_once URLSLAB_PLUGIN_DIR . '/includes/cron/class-urlslab-offload-cron.php';
 		$cron_job_offload = new Urlslab_Offload_Cron();
-
 		$this->loader->add_action( 'urlslab_cron_hook', $cron_job_offload, 'urlslab_cron_exec', 10, 0 );
 
-		if ( ! wp_next_scheduled( 'urlslab_offload_cron_hook' ) ) {
-			wp_schedule_event( time(), 'every_minute', 'urlslab_offload_cron_hook' );
-		}
+		require_once URLSLAB_PLUGIN_DIR . '/includes/cron/class-urlslab-convert-images-cron.php';
+		$cron_job_convert = new Urlslab_Convert_Images_Cron();
 
+		$this->loader->add_action( 'urlslab_cron_hook', $cron_job_convert, 'urlslab_cron_exec', 10, 0 );
 	}
 
 	/**

--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -338,7 +338,6 @@ class Urlslab {
 		$cron_job_convert = new Urlslab_Convert_Images_Cron();
 
 		$this->loader->add_action( 'urlslab_cron_hook', $cron_job_convert, 'urlslab_cron_exec', 10, 0 );
-		$this->loader->add_action( 'admin_init', $cron_job_convert, 'urlslab_cron_exec', 10, 0 );
 	}
 
 	/**

--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -338,6 +338,7 @@ class Urlslab {
 		$cron_job_convert = new Urlslab_Convert_Images_Cron();
 
 		$this->loader->add_action( 'urlslab_cron_hook', $cron_job_convert, 'urlslab_cron_exec', 10, 0 );
+		$this->loader->add_action( 'admin_init', $cron_job_convert, 'urlslab_cron_exec', 10, 0 );
 	}
 
 	/**

--- a/includes/cron/class-urlslab-convert-images-cron.php
+++ b/includes/cron/class-urlslab-convert-images-cron.php
@@ -1,0 +1,162 @@
+<?php
+
+class Urlslab_Convert_Images_Cron {
+	private $start_time;
+	const MAX_RUN_TIME = 10;
+
+	public function urlslab_cron_exec() {
+
+		if (
+			! function_exists( 'imagewebp' ) ||
+			! function_exists( 'imagecreatefrompng' ) ||
+			! function_exists( 'imagecreatefromjpeg' )
+		) {
+			return;
+		}
+
+		$this->start_time = time();
+		while ( time() - $this->start_time < self::MAX_RUN_TIME && $this->convert_next_file() ) {
+		}
+	}
+
+	private function convert_next_file() {
+		global $wpdb;
+
+		$values = get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_WEBP_TYPES_TO_CONVERT, Urlslab_Media_Offloader_Widget::SETTING_DEFAULT_WEBP_TYPES_TO_CONVERT );
+		if ( empty( $values ) ) {
+			return false;
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $values ), '%s' ) );
+		array_unshift( $values, Urlslab_Driver::STATUS_ACTIVE, Urlslab_File_Data::USE_WEBP_YES );
+
+		$file_row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM ' . URLSLAB_FILES_TABLE . ' WHERE filestatus = %s AND use_webp = %s AND webp_fileid IS NULL AND filetype IN (' . $placeholders . ') LIMIT 1', $values ),
+			ARRAY_A
+		);
+
+		if ( empty( $file_row ) ) {
+			return false;   //No rows to process
+		}
+
+		$file = new Urlslab_File_Data( $file_row );
+		if ( strlen( $file->get_webp_fileid() ) ) {
+			//This file is already processing or processed
+			return true;
+		}
+
+		//update status to processing (lock file)
+		$wpdb->update(
+			URLSLAB_FILES_TABLE,
+			array(
+				'webp_fileid' => Urlslab_File_Data::USE_WEBP_PROCESSING,
+			),
+			array(
+				'fileid' => $file->get_fileid(),
+				'webp_fileid' => Urlslab_File_Data::USE_WEBP_YES,
+			)
+		);
+
+		if ( ! Urlslab_Driver::get_driver( $file )->is_connected() ) {
+			//NOT connected, continue with next file
+			return true;
+		}
+
+
+		$tmp_name = wp_tempnam();
+		if ( Urlslab_Driver::get_driver( $file )->save_to_file( $file, $tmp_name ) ) {
+
+			switch ( $file->get_filetype() ) {
+				case 'image/png':
+					$im = imagecreatefrompng( $tmp_name );
+					break;
+				case 'image/jpeg':
+					$im = imagecreatefromjpeg( $tmp_name );
+					break;
+				default:
+					//unsupported file type
+					return true;
+			}
+
+			unlink( $tmp_name );
+
+			$webp_name = wp_tempnam();
+			if (
+				! imagewebp(
+					$im,
+					$webp_name,
+					get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_WEPB_QUALITY, Urlslab_Media_Offloader_Widget::SETTING_DEFAULT_WEPB_QUALITY )
+				)
+			) {
+				unlink( $webp_name );
+				return false;
+			}
+
+			$webp_file = new Urlslab_File_Data(
+				array(
+					'url' => $file->get_url( '.webp' ),
+					'filename' => $file->get_filename() . '.webp',
+					'filesize' => filesize( $webp_name ),
+					'filetype' => 'image/webp',
+					'width' => $file->get_width(),
+					'height' => $file->get_height(),
+					'filestatus' => Urlslab_Driver::STATUS_PENDING,
+					'local_file' => $webp_name,
+					'driver' => $file->get_driver(),
+					'use_webp' => Urlslab_File_Data::USE_WEBP_NO,
+				)
+			);
+
+			if ( $this->insert_webp_file( $webp_file ) && Urlslab_Driver::get_driver( $webp_file )->upload_content( $webp_file ) ) {
+				$wpdb->update(
+					URLSLAB_FILES_TABLE,
+					array(
+						'filestatus' => Urlslab_Driver::STATUS_ACTIVE,
+					),
+					array(
+						'fileid' => $webp_file->get_fileid(),
+					)
+				);
+				$wpdb->update(
+					URLSLAB_FILES_TABLE,
+					array(
+						'webp_fileid' => $webp_file->get_fileid(),
+					),
+					array(
+						'fileid' => $file->get_fileid(),
+					)
+				);
+			}
+			unlink( $webp_name );
+		}
+		return true;
+	}
+
+
+	private function insert_webp_file( Urlslab_File_Data $file ): bool {
+		global $wpdb;
+
+		$data = array(
+			'fileid' => $file->get_fileid(),
+			'url' => $file->get_url(),
+			'local_file' => $file->get_local_file(),
+			'filename' => $file->get_filename(),
+			'filesize' => $file->get_filesize(),
+			'filetype' => $file->get_filetype(),
+			'filestatus' => $file->get_filestatus(),
+			'driver' => $file->get_driver(),
+			'width' => $file->get_width(),
+			'height' => $file->get_height(),
+			'use_webp' => Urlslab_File_Data::USE_WEBP_NO,
+		);
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				'INSERT IGNORE INTO ' . URLSLAB_FILES_TABLE . // phpcs:ignore
+				' (' . implode( ',', array_keys( $data ) ) . // phpcs:ignore
+				') VALUES (%s, %s, %s, %s, %d, %s, %s, %s, %d, %d, %s)',
+				array_values( $data )
+			)
+		);
+	}
+}

--- a/includes/cron/class-urlslab-convert-images-cron.php
+++ b/includes/cron/class-urlslab-convert-images-cron.php
@@ -31,7 +31,7 @@ class Urlslab_Convert_Images_Cron {
 		array_unshift( $values, Urlslab_Driver::STATUS_ACTIVE, Urlslab_File_Data::USE_WEBP_YES );
 
 		$file_row = $wpdb->get_row(
-			$wpdb->prepare( 'SELECT * FROM ' . URLSLAB_FILES_TABLE . ' WHERE filestatus = %s AND use_webp = %s AND webp_fileid IS NULL AND filetype IN (' . $placeholders . ') LIMIT 1', $values ),
+			$wpdb->prepare( 'SELECT * FROM ' . URLSLAB_FILES_TABLE . ' WHERE filestatus = %s AND use_webp = %s AND webp_fileid IS NULL AND filetype IN (' . $placeholders . ') LIMIT 1', $values ), // phpcs:ignore
 			ARRAY_A
 		);
 

--- a/includes/cron/class-urlslab-offload-cron.php
+++ b/includes/cron/class-urlslab-offload-cron.php
@@ -130,6 +130,7 @@ class Urlslab_Offload_Cron {
 				URLSLAB_FILES_TABLE,
 				array(
 					'filestatus' => Urlslab_Driver::STATUS_ACTIVE,
+					'filetype' => $file->get_filetype(),
 				),
 				array(
 					'fileid' => $file->get_fileid(),

--- a/includes/cron/class-urlslab-offload-cron.php
+++ b/includes/cron/class-urlslab-offload-cron.php
@@ -2,7 +2,7 @@
 
 class Urlslab_Offload_Cron {
 	private $start_time;
-	const MAX_RUN_TIME = 20;
+	const MAX_RUN_TIME = 10;
 
 	public const SETTING_NAME_SCHEDULER_POINTER = 'urlslab_sched_pointer';
 

--- a/includes/cron/class-urlslab-screenshot-cron.php
+++ b/includes/cron/class-urlslab-screenshot-cron.php
@@ -17,14 +17,14 @@ class Urlslab_Screenshot_Cron {
 			try {
 				if ( $schedules ) {
 					$this->handle_schedules( $schedules );
-				}           
+				}
 			} catch ( Exception $e ) {
 				urlslab_debug_log( $e );
 				break;
 			}
 
 
-			if ( count( $schedules ) < 100 or ( time() - $start_time > 30 ) ) {
+			if ( count( $schedules ) < 100 or ( time() - $start_time > 10 ) ) {
 				break;
 			}
 		}

--- a/includes/driver/class-urlslab-driver.php
+++ b/includes/driver/class-urlslab-driver.php
@@ -52,9 +52,6 @@ abstract class Urlslab_Driver {
 			if ( $file_size && ( empty( $file->get_filesize() ) || $file->get_filesize() != $file_size ) ) {
 				$update_data['filesize'] = $file_size;
 			}
-			if ( 0 == $file->get_width() || 0 == $file->get_height() ) {
-				$size = getimagesize($file->get_local_file());
-			}
 			$result = $this->save_file_to_storage( $file, $file->get_local_file() );
 		} elseif ( strlen( $file->get_url() ) ) {
 			$local_tmp_file = download_url( $file->get_url() );
@@ -65,10 +62,6 @@ abstract class Urlslab_Driver {
 			if ( $file_size && ( empty( $file->get_filesize() ) || $file->get_filesize() != $file_size ) ) {
 				$update_data['filesize'] = $file_size;
 			}
-			if ( 0 == $file->get_width() || 0 == $file->get_height() ) {
-				$size = getimagesize($local_tmp_file);
-			}
-
 			$result = $this->save_file_to_storage( $file, $local_tmp_file );
 			unlink( $local_tmp_file );
 		}

--- a/includes/driver/class-urlslab-driver.php
+++ b/includes/driver/class-urlslab-driver.php
@@ -52,6 +52,9 @@ abstract class Urlslab_Driver {
 			if ( $file_size && ( empty( $file->get_filesize() ) || $file->get_filesize() != $file_size ) ) {
 				$update_data['filesize'] = $file_size;
 			}
+			if ( 0 == $file->get_width() || 0 == $file->get_height() ) {
+				$size = getimagesize($file->get_local_file());
+			}
 			$result = $this->save_file_to_storage( $file, $file->get_local_file() );
 		} elseif ( strlen( $file->get_url() ) ) {
 			$local_tmp_file = download_url( $file->get_url() );
@@ -62,6 +65,10 @@ abstract class Urlslab_Driver {
 			if ( $file_size && ( empty( $file->get_filesize() ) || $file->get_filesize() != $file_size ) ) {
 				$update_data['filesize'] = $file_size;
 			}
+			if ( 0 == $file->get_width() || 0 == $file->get_height() ) {
+				$size = getimagesize($local_tmp_file);
+			}
+
 			$result = $this->save_file_to_storage( $file, $local_tmp_file );
 			unlink( $local_tmp_file );
 		}

--- a/includes/services/class-urlslab-file-data.php
+++ b/includes/services/class-urlslab-file-data.php
@@ -307,7 +307,7 @@ class Urlslab_File_Data {
 		return $this->height ?? 0;
 	}
 
-	public function get_url($append_file_name = '') {
+	public function get_url( $append_file_name = '' ) {
 		$parsed_url = parse_url( $this->url );
 		$scheme = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : parse_url( get_site_url(), PHP_URL_SCHEME ) . '://';
 		$host = isset( $parsed_url['host'] ) ? $parsed_url['host'] : parse_url( get_site_url(), PHP_URL_HOST );
@@ -364,7 +364,9 @@ class Urlslab_File_Data {
 	}
 
 	public function has_webp_alternative() {
-		return get_option(Urlslab_Media_Offloader_Widget::SETTING_NAME_USE_WEBP_ALTERNATIVE, true) && $this->use_webp == self::USE_WEBP_YES && ! 32 == strlen( $this->webp_fileid );
+		return true === get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_USE_WEBP_ALTERNATIVE, true ) &&
+			self::USE_WEBP_YES === $this->use_webp &&
+			32 === strlen( $this->webp_fileid );
 	}
 
 	public function get_webp_fileid() {

--- a/includes/services/class-urlslab-file-data.php
+++ b/includes/services/class-urlslab-file-data.php
@@ -13,6 +13,12 @@ class Urlslab_File_Data {
 	private $local_file;
 	private $driver;
 	private $last_seen;
+	private $webp_fileid;
+	private $use_webp;
+
+	const USE_WEBP_YES = 'Y';
+	const USE_WEBP_PROCESSING = 'P';
+	const USE_WEBP_NO = 'N';
 
 	static $mime_types = array(
 		'txt' => 'text/plain',
@@ -232,8 +238,27 @@ class Urlslab_File_Data {
 		$this->local_file = $file['local_file'] ?? '';
 		$this->driver = $file['driver'] ?? '';
 		$this->last_seen = $file['last_seen'] ?? null;
+		$this->use_webp = $file['use_webp'] ?? self::USE_WEBP_YES;
+		$this->webp_fileid = $file['webp_fileid'] ?? null;
 	}
 
+	public function as_array() {
+		return array(
+			'url' => $this->get_url(),
+			'fileid' => $this->get_fileid(),
+			'filename' => $this->get_filename(),
+			'filesize' => $this->get_filesize(),
+			'filetype' => $this->get_filetype(),
+			'width' => $this->get_width(),
+			'height' => $this->get_height(),
+			'filestatus' => $this->get_filestatus(),
+			'local_file' => $this->get_local_file(),
+			'driver' => $this->get_driver(),
+			'last_seen' => $this->get_last_seen(),
+			'use_webp' => $this->use_webp,
+			'webp_fileid' => $this->get_webp_fileid(),
+		);
+	}
 
 	public function get_fileid() {
 		if ( ! empty( $this->fileid ) ) {
@@ -282,7 +307,7 @@ class Urlslab_File_Data {
 		return $this->height ?? 0;
 	}
 
-	public function get_url() {
+	public function get_url($append_file_name = '') {
 		$parsed_url = parse_url( $this->url );
 		$scheme = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : parse_url( get_site_url(), PHP_URL_SCHEME ) . '://';
 		$host = isset( $parsed_url['host'] ) ? $parsed_url['host'] : parse_url( get_site_url(), PHP_URL_HOST );
@@ -292,7 +317,7 @@ class Urlslab_File_Data {
 		$pass = ( $user || $pass ) ? "$pass@" : '';
 		$path = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
 		$query = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
-		return "$scheme$user$pass$host$port$path$query";
+		return "$scheme$user$pass$host$port$path$append_file_name$query";
 	}
 
 	private function get_url_no_protocol() {
@@ -336,6 +361,14 @@ class Urlslab_File_Data {
 
 	public function set_driver( $driver ) {
 		$this->driver = $driver;
+	}
+
+	public function has_webp_alternative() {
+		return get_option(Urlslab_Media_Offloader_Widget::SETTING_NAME_USE_WEBP_ALTERNATIVE, true) && $this->use_webp == self::USE_WEBP_YES && ! 32 == strlen( $this->webp_fileid );
+	}
+
+	public function get_webp_fileid() {
+		return $this->webp_fileid;
 	}
 
 }

--- a/includes/widgets/class-urlslab-media-offloader-widget.php
+++ b/includes/widgets/class-urlslab-media-offloader-widget.php
@@ -52,7 +52,7 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 	public const SETTING_DEFAULT_WEBP_TYPES_TO_CONVERT = array( 'image/png', 'image/jpeg' );
 
 	public const SETTING_NAME_WEPB_QUALITY = 'urlslab_webp_quality';
-	public const SETTING_DEFAULT_WEPB_QUALITY = 100;
+	public const SETTING_DEFAULT_WEPB_QUALITY = 80;
 
 	/**
 	 */
@@ -501,7 +501,7 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 	public function handle_webp_alternative( DOMElement $element, Urlslab_File_Data $file_obj, array $files, DOMDocument $document ) {
 		if ( 'img' === $element->tagName && $file_obj->has_webp_alternative() && isset( $files[ $file_obj->get_webp_fileid() ] ) ) {
 			$webp_file_obj = $files[ $file_obj->get_webp_fileid() ];
-			if ( $webp_file_obj->get_filestatus() == Urlslab_Driver::STATUS_ACTIVE ) {
+			if ( $webp_file_obj->get_filestatus() == Urlslab_Driver::STATUS_ACTIVE && $webp_file_obj->get_filesize() < $file_obj->get_filesize() ) {
 				$source_url = Urlslab_Driver::get_driver( $webp_file_obj )->get_url( $webp_file_obj );
 				if ( $source_url ) {
 					if ( 'picture' === $element->parentNode->tagName ) {
@@ -519,7 +519,7 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 						$source_element->setAttribute( 'srcset', $source_url );
 						$source_element->setAttribute( 'type', $webp_file_obj->get_filetype() );
 						$picture_element->appendChild( $source_element );
-						$picture_element->appendChild( $element );
+						$picture_element->appendChild( clone $element );
 						$element->parentNode->replaceChild( $picture_element, $element );
 					}
 				}

--- a/includes/widgets/class-urlslab-media-offloader-widget.php
+++ b/includes/widgets/class-urlslab-media-offloader-widget.php
@@ -46,6 +46,13 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 	private int $SETTING_TRANSFER_FROM_DRIVER_S3 = 0;
 	private int $SETTING_TRANSFER_FROM_DRIVER_DB = 0;
 
+	public const SETTING_NAME_USE_WEBP_ALTERNATIVE = 'urlslab_use_webp';
+
+	public const SETTING_NAME_WEBP_TYPES_TO_CONVERT = 'urlslab_webp_types';
+	public const SETTING_DEFAULT_WEBP_TYPES_TO_CONVERT = array( 'image/png', 'image/jpeg' );
+
+	public const SETTING_NAME_WEPB_QUALITY = 'urlslab_webp_quality';
+	public const SETTING_DEFAULT_WEPB_QUALITY = 100;
 
 	/**
 	 */
@@ -232,13 +239,14 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 			if ( empty( $urls ) ) {
 				return $content;
 			}
-			$new_urls = $this->get_new_urls( array_keys( $urls ) );
+			$files = $this->get_files_for_urls( array_keys( $urls ) );
 
-			foreach ( $new_urls as $fileid => $file_obj ) {
+			foreach ( $files as $fileid => $file_obj ) {
+
 				if ( $file_obj->get_filestatus() == Urlslab_Driver::STATUS_ACTIVE ) {
-					//set new url to all elements with this url
 					$new_url = Urlslab_Driver::get_driver( $file_obj )->get_url( $file_obj );
-					if ( $new_url ) {
+					if ( ! empty( $new_url ) ) {
+						//set new url to all elements with this url
 						foreach ( $urls[ $fileid ] as $attribute_name => $elements ) {
 							foreach ( $elements as $element ) {
 								$element['element']->setAttribute(
@@ -249,6 +257,8 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 										$element['element']->getAttribute( $attribute_name )
 									)
 								);
+
+								$this->handle_webp_alternative( $element['element'], $file_obj, $files, $document );
 							}
 							$found_urls[] = $fileid;
 						}
@@ -260,7 +270,7 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 			$this->update_last_seen_date( $found_urls );
 
 			$this->schedule_missing_images( $urls );
-			if ( count( $new_urls ) > 0 ) {
+			if ( count( $files ) > 0 ) {
 				return $document->saveHTML();
 			}
 
@@ -271,7 +281,16 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 		}
 	}
 
-	private function get_new_urls( array $old_url_ids ) {
+	private function has_picture_webp_source( DOMElement $element ) {
+		foreach ( $element->childNodes as $child_node ) {
+			if ( 'source' == $child_node->tagName && 'image/webp' === $child_node->getAttribute( 'type' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function get_files_for_urls( array $old_url_ids ) {
 		global $wpdb;
 		$new_urls = array();
 		$results = $wpdb->get_results(
@@ -281,9 +300,29 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 			),
 			'ARRAY_A'
 		);
+
+		$arr_webp_alternatives = array();
+
 		foreach ( $results as $file_array ) {
 			$file_obj = new Urlslab_File_Data( $file_array );
 			$new_urls[ $file_obj->get_fileid() ] = $file_obj;
+			if ( $file_obj->has_webp_alternative() ) {
+				$arr_webp_alternatives[] = $file_obj->get_webp_fileid();
+			}
+		}
+
+		if ( ! empty( $arr_webp_alternatives ) ) {
+			$results = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT * FROM ' . URLSLAB_FILES_TABLE . ' WHERE fileid in (' . trim( str_repeat( '%s,', count( $arr_webp_alternatives ) ), ',' ) . ')', // phpcs:ignore
+					$arr_webp_alternatives
+				),
+				'ARRAY_A'
+			);
+			foreach ( $results as $file_array ) {
+				$file_obj = new Urlslab_File_Data( $file_array );
+				$new_urls[ $file_obj->get_fileid() ] = $file_obj;
+			}
 		}
 		return $new_urls;
 	}
@@ -449,6 +488,43 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 		$this->SETTING_TRANSFER_FROM_DRIVER_DB = $option[ self::SETTING_NAME_TRANSFER_FROM_DRIVER_DB ];
 
 		update_option( $option_name, $option );
+	}
+
+	/**
+	 * @param $element
+	 * @param $file_obj
+	 * @param array $files
+	 * @param DOMDocument $document
+	 * @return array
+	 * @throws DOMException
+	 */
+	public function handle_webp_alternative( DOMElement $element, Urlslab_File_Data $file_obj, array $files, DOMDocument $document ) {
+		if ( 'img' === $element->tagName && $file_obj->has_webp_alternative() && isset( $files[ $file_obj->get_webp_fileid() ] ) ) {
+			$webp_file_obj = $files[ $file_obj->get_webp_fileid() ];
+			if ( $webp_file_obj->get_filestatus() == Urlslab_Driver::STATUS_ACTIVE ) {
+				$source_url = Urlslab_Driver::get_driver( $webp_file_obj )->get_url( $webp_file_obj );
+				if ( $source_url ) {
+					if ( 'picture' === $element->parentNode->tagName ) {
+						//parent is picture tag, check if one of sources is webp
+						if ( ! $this->has_picture_webp_source( $element->parentNode ) ) {
+							$source_element = $document->createElement( 'source' );
+							$source_element->setAttribute( 'srcset', $source_url );
+							$source_element->setAttribute( 'type', $webp_file_obj->get_filetype() );
+							$element->parentNode->appendChild( $source_element );
+						}
+					} else {
+						//encapsulate img into picture element and add source tag for webp
+						$picture_element = $document->createElement( 'picture' );
+						$source_element = $document->createElement( 'source' );
+						$source_element->setAttribute( 'srcset', $source_url );
+						$source_element->setAttribute( 'type', $webp_file_obj->get_filetype() );
+						$picture_element->appendChild( $source_element );
+						$picture_element->appendChild( $element );
+						$element->parentNode->replaceChild( $picture_element, $element );
+					}
+				}
+			}
+		}
 	}
 
 }

--- a/urlslab.php
+++ b/urlslab.php
@@ -36,7 +36,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-const URLSLAB_VERSION = '1.5.0';
+const URLSLAB_VERSION = '1.6.0';
 const URLSLAB_VERSION_SETTING = 'urlslab_ver';
 
 /**


### PR DESCRIPTION
**Changes proposed in this Pull Request**
webp files are generated on the background and served as picture alternative


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues/issues/669
