### PR TITLE
fix: set image height and width if missing during transfer

### DIFF
--- a/includes/driver/class-urlslab-driver.php
+++ b/includes/driver/class-urlslab-driver.php
@@ -52,6 +52,13 @@ abstract class Urlslab_Driver {
 			if ( $file_size && ( empty( $file->get_filesize() ) || $file->get_filesize() != $file_size ) ) {
 				$update_data['filesize'] = $file_size;
 			}
+			if ( empty( $file->get_height() ) || 0 === $file->get_height() || empty( $file->get_width() ) || 0 === $file->get_width() ) {
+				$size = getimagesize( $file->get_local_file() );
+				if ( $size ) {
+					$update_data['width'] = $size[0];
+					$update_data['height'] = $size[1];
+				}
+			}
 			$result = $this->save_file_to_storage( $file, $file->get_local_file() );
 		} elseif ( strlen( $file->get_url() ) ) {
 			$local_tmp_file = download_url( $file->get_url() );
@@ -61,6 +68,13 @@ abstract class Urlslab_Driver {
 			$file_size = filesize( $local_tmp_file );
 			if ( $file_size && ( empty( $file->get_filesize() ) || $file->get_filesize() != $file_size ) ) {
 				$update_data['filesize'] = $file_size;
+			}
+			if ( empty( $file->get_height() ) || 0 === $file->get_height() || empty( $file->get_width() ) || 0 === $file->get_width() ) {
+				$size = getimagesize( $local_tmp_file );
+				if ( $size ) {
+					$update_data['width'] = $size[0];
+					$update_data['height'] = $size[1];
+				}
 			}
 			$result = $this->save_file_to_storage( $file, $local_tmp_file );
 			unlink( $local_tmp_file );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
during upload of file to driver we can update image dimensions


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues/issues/675
