### PR TITLE
added meta tags functionality

### DIFF
--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -310,7 +310,7 @@ class Urlslab {
 		//head content
 		//# TODO - parsing of header should be added and the meta tag widget should not depend on <head></head>
 		$this->loader->add_action( 'wp_head', $this, 'buffer_head_start', 0 );
-		$this->loader->add_action( 'wp_head', $this, 'buffer_end', 1000 );
+		$this->loader->add_action( 'wp_head', $this, 'buffer_end', PHP_INT_MAX );
 
 		//body content
 		$this->loader->add_action( 'wp_body_open', $this, 'buffer_content_start', PHP_INT_MAX );

--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -309,8 +309,8 @@ class Urlslab {
 
 		//head content
 		//# TODO - parsing of header should be added and the meta tag widget should not depend on <head></head>
-		//      $this->loader->add_action( 'get_template_part_templates/head', $this, 'buffer_head_start', -100000 );
-		//      $this->loader->add_action( 'get_template_part_lib/pagesources', $this, 'buffer_end', 100000 );
+		$this->loader->add_action( 'wp_head', $this, 'buffer_head_start', 0 );
+		$this->loader->add_action( 'wp_head', $this, 'buffer_end', 1000 );
 
 		//body content
 		$this->loader->add_action( 'wp_body_open', $this, 'buffer_content_start', PHP_INT_MAX );

--- a/includes/class-urlslab.php
+++ b/includes/class-urlslab.php
@@ -308,9 +308,12 @@ class Urlslab {
 		$this->loader->add_action( 'template_redirect', $plugin_public, 'download_offloaded_file' );
 
 		//head content
-		//# TODO - parsing of header should be added and the meta tag widget should not depend on <head></head>
-		$this->loader->add_action( 'wp_head', $this, 'buffer_head_start', 0 );
-		$this->loader->add_action( 'wp_head', $this, 'buffer_end', PHP_INT_MAX );
+		$urlslab_user = Urlslab_User_Widget::get_instance();
+		if ( $urlslab_user->is_widget_activated( 'urlslab-meta-tag' ) ) {
+			//# Only adding header hook if the widget is activated by the user
+			$this->loader->add_action( 'wp_head', $this, 'buffer_head_start', 0 );
+			$this->loader->add_action( 'wp_head', $this, 'buffer_end', PHP_INT_MAX );
+		}
 
 		//body content
 		$this->loader->add_action( 'wp_body_open', $this, 'buffer_content_start', PHP_INT_MAX );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
added meta tags functionality. added the feature to add the corresponding WP action only if the widget is activated
From now on in LA installations, the meta tags widget should be deactivated in order to avoid incompatiblities with LA theme and urlslab plugin. The header action is called multiple times from the code in urlslab plugin which is addressed in https://github.com/QualityUnit/web-issues/issues/761

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/web-issues/issues/760
