### PR TITLE
fix: fatal error to read env variable, s3 connection validation

### DIFF
--- a/admin/src/components/SettingsOption.jsx
+++ b/admin/src/components/SettingsOption.jsx
@@ -22,7 +22,7 @@ export default function SettingsOption( { settingId, option, renderTooltip } ) {
 	const [ status, setStatus ] = useState( );
 
 	const handleApiCall = async () => {
-		renderTooltip( { status: 'activeApiCall', message: 'Job is running…' } );
+		renderTooltip( { status: 'activeApiCall', message: 'Executing…' } );
 		const result = await fetchData( value );
 		if ( result ) {
 			renderTooltip( { status: 'successApiCall', message: result } );
@@ -31,7 +31,7 @@ export default function SettingsOption( { settingId, option, renderTooltip } ) {
 			}, 3000 );
 			return false;
 		}
-		renderTooltip( { status: 'errorApiCall', message: 'Error occured' } );
+		renderTooltip( { status: 'errorApiCall', message: 'Failed' } );
 		setTimeout( () => {
 			renderTooltip();
 		}, 3000 );

--- a/includes/api/class-urlslab-api-files.php
+++ b/includes/api/class-urlslab-api-files.php
@@ -103,6 +103,7 @@ class Urlslab_Api_Files extends Urlslab_Api_Table {
 			)
 		);
 
+		register_rest_route( self::NAMESPACE, $base . '/validate_s3', $this->get_route_validate_s3() );
 		register_rest_route( self::NAMESPACE, $base . '/(?P<fileid>[0-9a-zA-Z]+)/urls', $this->get_route_file_urls() );
 		register_rest_route( self::NAMESPACE, $base . '/(?P<fileid>[0-9a-zA-Z]+)/urls/count', $this->get_count_route( $this->get_route_file_urls() ) );
 	}
@@ -201,6 +202,14 @@ class Urlslab_Api_Files extends Urlslab_Api_Table {
 		$this->on_items_updated();
 
 		return new WP_REST_Response( __( 'Deleted' ), 200 );
+	}
+
+	public function validate_s3( WP_REST_Request $request ) {
+		if  ( Urlslab_Driver::get_driver(Urlslab_Driver::DRIVER_S3)->is_connected() ) {
+			return new WP_REST_Response( __( 'S3 connected' ), 200 );
+		} else {
+			return new WP_REST_Response( __( 'S3 not connected' ), 500 );
+		}
 	}
 
 	public function get_row_object( $params = array() ): Urlslab_Data {
@@ -302,5 +311,22 @@ class Urlslab_Api_Files extends Urlslab_Api_Table {
 		$sql->add_sorting( $columns, $request );
 
 		return $sql;
+	}
+
+	public function validate_s3_permissions_check( $request ) {
+		return current_user_can( 'administrator' ) || current_user_can( 'manage_options' );
+	}
+
+	private function get_route_validate_s3() {
+		return array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'validate_s3' ),
+				'permission_callback' => array(
+					$this,
+					'validate_s3_permissions_check',
+				),
+			),
+		);
 	}
 }

--- a/includes/api/class-urlslab-api-files.php
+++ b/includes/api/class-urlslab-api-files.php
@@ -207,11 +207,13 @@ class Urlslab_Api_Files extends Urlslab_Api_Table {
 	public function validate_s3( WP_REST_Request $request ) {
 		/** @var Urlslab_Driver_S3 $driver */
 		$driver = Urlslab_Driver::get_driver( Urlslab_Driver::DRIVER_S3 );
-		if  ( $driver->is_connected() ) {
-			return new WP_REST_Response( __( 'S3 connected' ), 200 );
-		} else {
-			return new WP_REST_Response( __( 'S3 not connected' ), 500 );
+		try {
+			if ( $driver->is_connected() ) {
+				return new WP_REST_Response( __( 'S3 connected' ), 200 );
+			}
+		} catch ( Exception $e ) {
 		}
+		return new WP_REST_Response( __( 'S3 not connected' ), 500 );
 	}
 
 	public function get_row_object( $params = array() ): Urlslab_Data {

--- a/includes/api/class-urlslab-api-files.php
+++ b/includes/api/class-urlslab-api-files.php
@@ -205,7 +205,9 @@ class Urlslab_Api_Files extends Urlslab_Api_Table {
 	}
 
 	public function validate_s3( WP_REST_Request $request ) {
-		if  ( Urlslab_Driver::get_driver(Urlslab_Driver::DRIVER_S3)->is_connected() ) {
+		/** @var Urlslab_Driver_S3 $driver */
+		$driver = Urlslab_Driver::get_driver( Urlslab_Driver::DRIVER_S3 );
+		if  ( $driver->is_connected() ) {
 			return new WP_REST_Response( __( 'S3 connected' ), 200 );
 		} else {
 			return new WP_REST_Response( __( 'S3 not connected' ), 500 );

--- a/includes/driver/class-urlslab-driver-s3.php
+++ b/includes/driver/class-urlslab-driver-s3.php
@@ -142,27 +142,11 @@ class Urlslab_Driver_S3 extends Urlslab_Driver {
 	}
 
 	private function get_access_key() {
-		if ( strlen( $this->get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_S3_ACCESS_KEY ) ) ) {
-			return $this->get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_S3_ACCESS_KEY );
-		}
-
-		if ( strlen( env( 'AWS_KEY' ) ) ) {
-			return env( 'AWS_KEY' );
-		}
-
-		return false;
+		return $this->get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_S3_ACCESS_KEY );
 	}
 
 	private function get_secret_key() {
-		if ( strlen( $this->get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_S3_SECRET ) ) ) {
-			return $this->get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_S3_SECRET );
-		}
-
-		if ( strlen( env( 'AWS_SECRET' ) ) ) {
-			return env( 'AWS_SECRET' );
-		}
-
-		return false;
+		return $this->get_option( Urlslab_Media_Offloader_Widget::SETTING_NAME_S3_SECRET );
 	}
 
 	private function getClient(): S3Client {

--- a/includes/widgets/class-urlslab-media-offloader-widget.php
+++ b/includes/widgets/class-urlslab-media-offloader-widget.php
@@ -510,6 +510,17 @@ class Urlslab_Media_Offloader_Widget extends Urlslab_Widget {
 			null,
 			's3'
 		);
+		$this->add_option_definition(
+			'btn_validate_s3',
+			'file/validate_s3',
+			false,
+			__( 'Validate S3 connection' ),
+			__( 'Validate, if connection to S3 is working' ),
+			self::OPTION_TYPE_BUTTON_API_CALL,
+			false,
+			null,
+			's3'
+		);
 
 		$this->add_options_form_section( 'img_opt', __( 'Image Optimisation Settings' ), __( 'Modern image types such as WebP and Avif are crucial to speeding up website loading. However, we can offer many other features that can help speed up your website even more.' ) );
 


### PR DESCRIPTION
I still don't know exact names of ENV variables for AWS, currently is possible to use env variables:
urlslab_AWS_S3_bucket
urlslab_AWS_S3_region
urlslab_AWS_S3_access_key
urlslab_AWS_S3_secret

Close https://github.com/QualityUnit/web-issues/issues/1474
