### PR TITLE
fix: don't store in attributes computed variables of shortcode

### DIFF
--- a/includes/cron/class-urlslab-generators-cron.php
+++ b/includes/cron/class-urlslab-generators-cron.php
@@ -85,9 +85,10 @@ class Urlslab_Generators_Cron extends Urlslab_Cron {
 					$row_obj->set_result( 'Video captions not available' );
 					$row_obj->set_status( Urlslab_Generator_Result_Row::STATUS_DISABLED );
 					$row_obj->update();
+
 					return true;
 				}
-				$command    = $widget->get_template_value(
+				$command = $widget->get_template_value(
 					'Never appologize! If you do NOT know the answer, return just text: ' . Urlslab_Generator_Result_Row::DO_NOT_KNOW . "!\n" . $row_shortcode->get_prompt() .
 					"\n\n--VIDEO CAPTIONS:\n{{video_captions_text}}\n--VIDEO CAPTIONS END\nANSWER:",
 					$attributes
@@ -110,8 +111,8 @@ class Urlslab_Generators_Cron extends Urlslab_Cron {
 
 				$filter = new DomainDataRetrievalContentQuery();
 				$filter->setLimit( 5 );
-				$ignore_query = 'false';
-				$custom_context = 'false';
+				$ignore_query      = 'false';
+				$custom_context    = 'false';
 				$context_mandatory = 'true';
 				if ( strlen( $row_obj->get_semantic_context() ) ) {
 					$request->setAugmentCommand( $row_obj->get_semantic_context() );
@@ -124,7 +125,7 @@ class Urlslab_Generators_Cron extends Urlslab_Cron {
 					$ignore_query = 'true';
 					$filter->setUrls( array( $row_obj->get_url_filter() ) );
 				} else {
-					$custom_context = 'true';
+					$custom_context    = 'true';
 					$context_mandatory = 'false';
 				}
 				$request->setFilter( $filter );

--- a/includes/widgets/class-urlslab-content-generator-widget.php
+++ b/includes/widgets/class-urlslab-content-generator-widget.php
@@ -162,7 +162,7 @@ class Urlslab_Content_Generator_Widget extends Urlslab_Widget {
 			array(
 				'shortcode_id'     => $atts['id'],
 				'semantic_context' => $this->get_template_value( $obj->get_semantic_context(), $atts ),
-				'prompt_variables' => json_encode( $atts ),
+				'prompt_variables' => json_encode( $this->unset_computed_variables( $atts ) ),
 				'url_filter'       => $this->get_template_value( $obj->get_url_filter(), $atts ),
 			),
 			false
@@ -179,10 +179,10 @@ class Urlslab_Content_Generator_Widget extends Urlslab_Widget {
 			$obj_result->set_status( Urlslab_Generator_Result_Row::STATUS_NEW );
 			$obj_result->insert_all( array( $obj_result ), true );
 		}
+		$this->track_usage( $obj_result );
 
 
 		if ( ! empty( $value ) ) {
-			$this->track_usage( $obj_result );
 
 			if ( empty( $atts['template'] ) && empty( trim( $obj->get_template() ) ) ) {
 				return $value;
@@ -553,5 +553,18 @@ class Urlslab_Content_Generator_Widget extends Urlslab_Widget {
 		$generator_url->set_shortcode_id( $obj->get_shortcode_id() );
 		$generator_url->set_hash_id( $obj->get_hash_id() );
 		$generator_url->insert_all( array( $generator_url ), true );
+	}
+
+	private function unset_computed_variables( array $atts ) {
+		unset( $atts['video_captions'] );
+		unset( $atts['video_captions_text'] );
+		unset( $atts['video_title'] );
+		unset( $atts['video_description'] );
+		unset( $atts['video_published_at'] );
+		unset( $atts['video_duration'] );
+		unset( $atts['video_channel_title'] );
+		unset( $atts['video_tags'] );
+
+		return $atts;
 	}
 }


### PR DESCRIPTION
- track shortcode from first view
- don't store computed variables in shortcode
