### PR TITLE
fix: recompute hash before insert

### DIFF
--- a/includes/data/class-urlslab-redirect-row.php
+++ b/includes/data/class-urlslab-redirect-row.php
@@ -216,7 +216,7 @@ class Urlslab_Redirect_Row extends Urlslab_Data {
 	}
 
 	protected function before_insert() {
-		$this->set_row_hash( $this->get_row_hash() );    //refresh hash
+		$this->set_row_hash( 0 );    //refresh hash
 		parent::before_insert();
 	}
 }


### PR DESCRIPTION
- insert fixed
- still not working UI ... when I insert new row and switch to Redirects table, count is updated, but list of rows is not refreshed and new row is not visible in the table

