### PR TITLE
[1524] fix: overview

### DIFF
--- a/admin/src/components/OverviewTemplate.jsx
+++ b/admin/src/components/OverviewTemplate.jsx
@@ -89,7 +89,7 @@ export default function Overview( { moduleId, noFAQ, noIntegrate, noCheckbox, ti
 				<div className="urlslab-overview-content">
 					{ title
 						? <h3> { title } </h3>
-						: moduleData?.title !== false && <h3> { moduleData.title } </h3>
+						: moduleData?.title && <h3> { moduleData.title } </h3>
 					}
 					{ children }
 				</div>

--- a/admin/src/modules/Schedule.jsx
+++ b/admin/src/modules/Schedule.jsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy, useState } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 
-import Overview from '../components/OverviewTemplate';
 import SchedulesOverview from '../overview/Schedules';
 import ModuleViewHeader from '../components/ModuleViewHeader';
 
@@ -24,9 +23,7 @@ export default function Schedule( { moduleId } ) {
 				noSettings
 				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
 			{ activeSection === 'overview' &&
-				<Overview moduleId={ moduleId }>
-					<SchedulesOverview />
-				</Overview>
+			<SchedulesOverview moduleId={ moduleId } />
 			}
 			{ activeSection === slug &&
 				<div className="urlslab-tableView">

--- a/admin/src/overview/Schedules.jsx
+++ b/admin/src/overview/Schedules.jsx
@@ -1,11 +1,20 @@
-export default function SchedulesOverview() {
+import { useState } from 'react';
+import Overview from '../components/OverviewTemplate';
+
+export default function SchedulesOverview( { moduleId } ) {
+	const [ section, setSection ] = useState( 'about' );
+
 	return (
-		<>
-			<br/>
-			<h1>Urlslab service</h1>
-			<h2>How can paid service help my Wordpress?</h2>
-			<p>Even you can use our plugin for free and laverage from multiple cool features, integration with our paid service will boost your web in the eyes of search engines thanks to following features:</p>
-			<p>Here should be explanation how credits work, what type of actions we charge and why sometime we return the credit to user (e.g. when we discover, that url doesn't need to be crawled</p>
-		</>
+		<Overview moduleId={ moduleId } section={ ( val ) => setSection( val ) } title="Urlslab service">
+			{
+				section === 'about' &&
+				<section>
+
+					<h2>How can paid service help my Wordpress?</h2>
+					<p>Even you can use our plugin for free and laverage from multiple cool features, integration with our paid service will boost your web in the eyes of search engines thanks to following features:</p>
+					<p>Here should be explanation how credits work, what type of actions we charge and why sometime we return the credit to user (e.g. when we discover, that url doesn't need to be crawled</p>
+				</section>
+			}
+		</Overview>
 	);
 }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Overview for schedules fixed. No /wp-json/urlslab/v1/billing/credits/events/count endpoint, add it please and counting will work (it HAS to be /wp-json/urlslab/v1/billing/credits/events/count as slug for table is /wp-json/urlslab/v1/billing/credits/events)

Close QualityUnit/web-issues#1524
