### PR TITLE
[Bug]: Wrong width of side menu when is nothing activated

### DIFF
--- a/admin/src/assets/styles/components/_MainMenu.scss
+++ b/admin/src/assets/styles/components/_MainMenu.scss
@@ -33,6 +33,7 @@
 
 	&.open {
 		max-width: $mainMenuWidth;
+		width: 100%;
 	}
 
 	&-title[class] {
@@ -77,7 +78,7 @@
 		margin: 0;
 		flex: 1 0 auto;
 
-		> * {
+		>* {
 			position: relative;
 			z-index: 1;
 		}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
fixed main menu width to fill wanted space even there are no so long menu items

Close QualityUnit/web-issues#1721
