### PR TITLE
[Bug]: Schedules JS Error & URL Monitoring popup notification

### DIFF
--- a/admin/src/components/ChangesPanel/ChangesPanel.jsx
+++ b/admin/src/components/ChangesPanel/ChangesPanel.jsx
@@ -57,11 +57,9 @@ function ChangesPanel() {
 			if ( result.ok ) {
 				return await result.json();
 			}
-			return [];
 		},
 		refetchOnWindowFocus: false,
 	} );
-
 	const chartResult = useQuery( {
 		queryKey: [ slug, 'chart', chartDateState.startDate, chartDateState.endDate ],
 		queryFn: async () => {
@@ -170,7 +168,7 @@ function ChangesPanel() {
 		columnHelper.display( {
 			id: 'diff_actions',
 			cell: ( cell ) => {
-				if ( tableResult.data.length > 1 && cell.row.index < tableResult.data.length - 1 ) {
+				if ( tableResult.isSuccess && tableResult.data.length > 1 && cell.row.index < tableResult.data.length - 1 ) {
 					return <DiffButton
 						onClick={ () => {
 							// removing selected rows
@@ -239,7 +237,7 @@ function ChangesPanel() {
 							</button>
 						</div>
 						<div className="p-l">
-							No Data found for this url. try to schedule this url to get data.
+							{ __( 'No Data found for this url. Try to schedule url to get data.' ) }
 						</div>
 					</div>
 				</div>

--- a/admin/src/modules/static/Schedule.jsx
+++ b/admin/src/modules/static/Schedule.jsx
@@ -1,5 +1,4 @@
 import { Suspense, lazy, useState } from 'react';
-import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import SchedulesOverview from '../../overview/Schedules';
@@ -14,7 +13,8 @@ export default function Schedule() {
 	const { __ } = useI18n();
 	const [ activeSection, setActiveSection ] = useState( 'overview' );
 
-	const { moduleId } = useOutletContext();
+	// define module id statically, this module is not included in api response to get value from query
+	const moduleId = 'urlslab-schedule';
 
 	const tableMenu = new Map( [
 		[ slug, __( 'Schedules' ) ],


### PR DESCRIPTION
**Changes proposed in this Pull Request**
#1801:
Fixed error in Schedules module.
There was missing moduleId as it was loaded automatically for all modules. Schedules module isn't included in api response with other modules, thus loaded id was undefined.

#1797:
Fixed checking for success table query result. Query always returned empty array this was considered as success even thats not true. 
Updated checking for query success on all places where result data could be manipulated.

**Testing instructions**
#1801:
Should not be present error in console while switching between subpages on module page.
Last visited subpage on module should be saved in internal db.

#1797:
Should be displayed notification message if table query to get results failed.

Close QualityUnit/web-issues#1801
Close QualityUnit/web-issues#1797

