### PR TITLE
fix: missing media plugin when media btn configured

### DIFF
--- a/admin/src/elements/Editor.jsx
+++ b/admin/src/elements/Editor.jsx
@@ -33,7 +33,7 @@ import 'tinymce/plugins/image';
 // import 'tinymce/plugins/insertdatetime';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
-// import 'tinymce/plugins/media';
+import 'tinymce/plugins/media';
 // import 'tinymce/plugins/nonbreaking';
 // import 'tinymce/plugins/pagebreak';
 // import 'tinymce/plugins/preview';


### PR DESCRIPTION
**Changes proposed in this Pull Request**
missing media plugin in TinyMCE when media btn configured caused slow initialization of TinyMCE
