### PR TITLE
[1889] fix: reverting disabled for existing filter

### DIFF
--- a/admin/src/components/TableFilterPanel.jsx
+++ b/admin/src/components/TableFilterPanel.jsx
@@ -134,6 +134,7 @@ export default function TableFilterPanel( { props, onEdit } ) {
 					defaultValue={ keyWithoutId || Object.keys( header )[ 0 ] }
 					defaultAccept
 					autoClose
+					disabled={ key ? true : false }
 					onChange={ handleKeyChange }
 				/>
 				{ ( state.filterObj.keyType && ( filters[ key ]?.op || state.filterObj.filterOp ) ) &&


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Reverting back disabled parameter for column selection filter on edit

Close QualityUnit/web-issues#1889
