### PR TITLE
[#1864] Add Tab navigation to React Router 

### DIFF
--- a/admin/src/app/router.jsx
+++ b/admin/src/app/router.jsx
@@ -40,6 +40,12 @@ const routes = [
 	{
 		path: 'Schedule',
 		element: <Schedule />,
+		children: [
+			{
+				path: ':section',
+				element: <Schedule />,
+			},
+		],
 	},
 	{
 		path: 'TagsLabels',

--- a/admin/src/app/router.jsx
+++ b/admin/src/app/router.jsx
@@ -12,9 +12,16 @@ const TagsLabels = lazy( () => import( '../modules/static/TagsLabels' ) );
 
 // routes generated on the base of modules files available in ./modules folder
 const modulesRoutes = modulesList.map( ( ( moduleName ) => {
+	const element = createElement( lazy( () => import( `../modules/${ moduleName }.jsx` ) ) );
 	return {
 		path: moduleName,
-		element: createElement( lazy( () => import( `../modules/${ moduleName }.jsx` ) ) ),
+		element,
+		children: [
+			{
+				path: ':section',
+				element,
+			},
+		],
 	};
 } ) );
 

--- a/admin/src/components/MainMenu.jsx
+++ b/admin/src/components/MainMenu.jsx
@@ -3,7 +3,7 @@ import { useLocation, Link } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 import { get, set, del } from 'idb-keyval';
 
-import { renameModule } from '../lib/helpers';
+import { getModuleNameFromRoute, renameModule } from '../lib/helpers';
 import useModulesQuery from '../queries/useModulesQuery';
 
 import { ReactComponent as MenuArrow } from '../assets/images/arrow-simple.svg';
@@ -15,7 +15,7 @@ import '../assets/styles/components/_MainMenu.scss';
 export default function MainMenu() {
 	const { __ } = useI18n();
 	const mainmenu = useRef();
-	const route = useLocation().pathname;
+	const moduleInRoute = getModuleNameFromRoute( useLocation().pathname );
 
 	const { data: modules = {}, isSuccess: isSuccessModules } = useModulesQuery();
 
@@ -49,7 +49,7 @@ export default function MainMenu() {
 	};
 
 	const activator = ( activateRoute ) => {
-		if ( '/' + activateRoute === route ) {
+		if ( activateRoute === moduleInRoute ) {
 			return 'active';
 		}
 		return '';

--- a/admin/src/components/ModuleViewHeader.jsx
+++ b/admin/src/components/ModuleViewHeader.jsx
@@ -1,14 +1,13 @@
-import { useState, useCallback, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
-import { update, get } from 'idb-keyval';
+import { update } from 'idb-keyval';
 
 import SimpleButton from '../elements/SimpleButton';
 
 import '../assets/styles/components/_ModuleViewHeader.scss';
 
-export default function ModuleViewHeader( { moduleId, moduleMenu, activeMenu, noSettings } ) {
+export default function ModuleViewHeader( { moduleId, moduleMenu, activeSection, noSettings } ) {
 	const { __ } = useI18n();
-	const [ active, setActive ] = useState( 'overview' );
 
 	const menuItems = new Map( [
 		[ 'overview', __( 'Overview' ) ],
@@ -21,63 +20,49 @@ export default function ModuleViewHeader( { moduleId, moduleMenu, activeMenu, no
 		} );
 	};
 
-	const handleMenu = ( menukey, returning ) => {
-		setActive( menukey );
-		if ( ! returning ) {
-			rememberActiveMenu( menukey );
-		}
-		if ( activeMenu ) {
-			activeMenu( menukey );
-		}
-	};
-
 	const activator = ( menukey ) => {
-		if ( menukey === active ) {
+		if ( menukey === activeSection ) {
 			return 'active';
 		}
 		return '';
 	};
 
-	const getActiveMenu = useCallback( async () => {
-		const moduleData = moduleId && await get( moduleId );
-
-		if ( moduleData?.activeMenu ) {
-			handleMenu( moduleData?.activeMenu, true );
-		}
-	}, [ ] );
-
-	useEffect( () => {
-		getActiveMenu();
-	}, [ ] );
-
 	return (
 
 		<div className="urlslab-moduleView-header">
 			<div className="urlslab-moduleView-headerTop">
-				<SimpleButton key={ 'overview' }
-					className={ activator( 'overview' ) }
-					onClick={ () => handleMenu( 'overview' ) }
-				>
-					{ menuItems.get( 'overview' ) }
-				</SimpleButton>
+				<Link to="overview" >
+					<SimpleButton
+						className={ activator( 'overview' ) }
+						onClick={ () => rememberActiveMenu( 'overview' ) }
+					>
+						{ menuItems.get( 'overview' ) }
+					</SimpleButton>
+				</Link>
 				{ moduleMenu
 					? Array.from( moduleMenu ).map( ( [ key, value ] ) => {
-						return <SimpleButton key={ key }
-							className={ activator( key ) }
-							onClick={ () => handleMenu( key ) }
-						>
-							{ value }
-						</SimpleButton>;
+						return (
+							<Link key={ key } to={ key } >
+								<SimpleButton
+									className={ activator( key ) }
+									onClick={ () => rememberActiveMenu( key ) }
+								>
+									{ value }
+								</SimpleButton>
+							</Link>
+						);
 					} )
 					: null
 				}
 				{ ! noSettings &&
-					<SimpleButton key={ 'settings' }
-						className={ activator( 'settings' ) }
-						onClick={ () => handleMenu( 'settings' ) }
-					>
-						{ menuItems.get( 'settings' ) }
-					</SimpleButton>
+					<Link to="settings">
+						<SimpleButton
+							className={ activator( 'settings' ) }
+							onClick={ () => rememberActiveMenu( 'settings' ) }
+						>
+							{ menuItems.get( 'settings' ) }
+						</SimpleButton>
+					</Link>
 				}
 			</div>
 		</div>

--- a/admin/src/hooks/useModuleDataByRoute.jsx
+++ b/admin/src/hooks/useModuleDataByRoute.jsx
@@ -4,17 +4,17 @@
 
 import { useLocation } from 'react-router-dom';
 
-import { renameModule } from '../lib/helpers';
+import { getModuleNameFromRoute, renameModule } from '../lib/helpers';
 import useModulesQuery from '../queries/useModulesQuery';
 
 const useModuleDataByRoute = () => {
 	const { data: modules } = useModulesQuery();
 	const location = useLocation();
-	const route = location.pathname;
-
 	let moduleData = {};
+
 	if ( modules && Object.values( modules ).length ) {
-		const moduleName = route.charAt( 0 ) === '/' ? route.slice( 1 ) : route;
+		const moduleName = getModuleNameFromRoute( location.pathname );
+
 		Object.values( modules ).every( ( module ) => {
 			if ( renameModule( module.id ) === moduleName ) {
 				moduleData = module;

--- a/admin/src/hooks/useModuleSectionRoute.jsx
+++ b/admin/src/hooks/useModuleSectionRoute.jsx
@@ -6,8 +6,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router-dom';
 import { get } from 'idb-keyval';
 
-const useModuleSectionRoute = ( availableRoutes ) => {
+const useModuleSectionRoute = ( availableRoutes, staticId = null ) => {
 	const { moduleId } = useOutletContext();
+
 	const [ activeSectionData, setActiveSectionData ] = useState( null );
 	const params = useParams();
 	const isRootRoute = Object.keys( params ).length === 0;
@@ -15,10 +16,10 @@ const useModuleSectionRoute = ( availableRoutes ) => {
 	// if it's root module route, check for last visited section
 	const checkLastVisitedTab = useCallback( async () => {
 		if ( isRootRoute ) {
-			const savedData = await get( moduleId );
+			const savedData = await get( staticId !== null ? staticId : moduleId );
 			setActiveSectionData( savedData );
 		}
-	}, [ isRootRoute, moduleId ] );
+	}, [ isRootRoute, moduleId, staticId ] );
 
 	useEffect( () => {
 		checkLastVisitedTab();

--- a/admin/src/hooks/useModuleSectionRoute.jsx
+++ b/admin/src/hooks/useModuleSectionRoute.jsx
@@ -1,0 +1,48 @@
+/**
+ * Hook to handle opened module section by route
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useOutletContext, useParams } from 'react-router-dom';
+import { get } from 'idb-keyval';
+
+const useModuleSectionRoute = ( availableRoutes ) => {
+	const { moduleId } = useOutletContext();
+	const [ activeSectionData, setActiveSectionData ] = useState( null );
+	const params = useParams();
+	const isRootRoute = Object.keys( params ).length === 0;
+
+	// if it's root module route, check for last visited section
+	const checkLastVisitedTab = useCallback( async () => {
+		if ( isRootRoute ) {
+			const savedData = await get( moduleId );
+			setActiveSectionData( savedData );
+		}
+	}, [ isRootRoute, moduleId ] );
+
+	useEffect( () => {
+		checkLastVisitedTab();
+	}, [ checkLastVisitedTab ] );
+
+	// accessed directly module route without defined section route
+	// ie. /LinkEnhancer
+	if ( isRootRoute ) {
+		if ( activeSectionData === undefined ) {
+			// not saved last visited section, return default
+			return 'overview';
+		}
+		// return null if not fetched yet, prevent showing overview while loading from idb-keyval
+		return activeSectionData?.activeMenu ? activeSectionData.activeMenu : null;
+	}
+
+	// defined section in route, return if defined section route exists
+	// ie. /LinkEnhancer/settings
+	if ( params.section && availableRoutes.includes( params.section ) ) {
+		return params.section;
+	}
+
+	// last chance, show overview also for non existing section routes
+	return 'overview';
+};
+
+export default useModuleSectionRoute;

--- a/admin/src/hooks/usePageTitle.jsx
+++ b/admin/src/hooks/usePageTitle.jsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import useModuleDataByRoute from './useModuleDataByRoute';
+import { getModuleNameFromRoute } from '../lib/helpers';
 
 const usePageTitle = () => {
 	const { __ } = useI18n();
@@ -13,14 +14,14 @@ const usePageTitle = () => {
 	const { title } = useModuleDataByRoute();
 
 	// routes are not case sensitive, compare route in lowercase to make sure to use correct title for route /Settings and /settigns too
-	switch ( location.pathname.toLowerCase() ) {
-		case '/':
+	switch ( getModuleNameFromRoute( location.pathname ).toLowerCase() ) {
+		case '':
 			return __( 'Modules' );
-		case '/settings':
+		case 'settings':
 			return __( 'Settings' );
-		case '/schedule':
+		case 'schedule':
 			return __( 'Schedules' );
-		case '/tagslabels':
+		case 'tagslabels':
 			return __( 'Tags' );
 		default:
 			// last chance, it's module or unexisting route that leads to root route

--- a/admin/src/lib/helpers.js
+++ b/admin/src/lib/helpers.js
@@ -14,6 +14,23 @@ export const renameModule = ( moduleId ) => {
 	}
 };
 
+// get module name from full route
+export const getModuleNameFromRoute = ( sourceRoute ) => {
+	const route = sourceRoute.charAt( 0 ) === '/' ? sourceRoute.slice( 1 ) : sourceRoute;
+	const routeParts = route.split( '/' );
+	return routeParts[ 0 ];
+};
+
+// get keys from Map object
+export const getMapKeysArray = ( items ) => {
+	if ( items ) {
+		return Array.from( items ).map( ( [ key ] ) => {
+			return key;
+		} );
+	}
+	return [];
+};
+
 // Delay some function (ie. onChange, onKeyUp)…
 // Usage delay(()=> some.function, time in ms)();
 let delayTimer = 0;

--- a/admin/src/modules/Cache.jsx
+++ b/admin/src/modules/Cache.jsx
@@ -1,28 +1,36 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import ModuleViewHeader from '../components/ModuleViewHeader';
 import CacheOverview from '../overview/Cache';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const CacheRulesTable = lazy( () => import( `../tables/CacheRulesTable.jsx` ) );
 
 export default function Cache() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
 		[ 'cache-rules', __( 'Cache Rules' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
+			<ModuleViewHeader
+				moduleId={ moduleId }
 				moduleMenu={ tableMenu }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<CacheOverview moduleId={ moduleId } />

--- a/admin/src/modules/CssOptimizer.jsx
+++ b/admin/src/modules/CssOptimizer.jsx
@@ -1,9 +1,11 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import HtmlOptimizerOverview from '../overview/HtmlOptimizer';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const CSSCacheTable = lazy( () => import( `../tables/CSSCacheTable.jsx` ) );
 const JSCacheTable = lazy( () => import( `../tables/JSCacheTable.jsx` ) );
@@ -11,8 +13,6 @@ const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
 export default function CssOptimizer() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
@@ -20,10 +20,19 @@ export default function CssOptimizer() {
 		[ 'js-cache', __( 'Cached JS Files' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<HtmlOptimizerOverview moduleId={ moduleId } />

--- a/admin/src/modules/CustomHtml.jsx
+++ b/admin/src/modules/CustomHtml.jsx
@@ -1,16 +1,17 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import ModuleViewHeader from '../components/ModuleViewHeader';
 import CustomHtmlOverview from '../overview/CustomHtml';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const CustomHtmlTable = lazy( () => import( `../tables/CustomHtmlTable.jsx` ) );
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
 export default function CustomHtml() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
 
 	const { moduleId } = useOutletContext();
 
@@ -18,12 +19,19 @@ export default function CustomHtml() {
 		[ 'custom-html', __( 'Custom HTML' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
 			<ModuleViewHeader
 				moduleId={ moduleId }
 				moduleMenu={ tableMenu }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<CustomHtmlOverview moduleId={ moduleId } />

--- a/admin/src/modules/Faq.jsx
+++ b/admin/src/modules/Faq.jsx
@@ -1,9 +1,11 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import FaqsOverview from '../overview/Faqs';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const FaqsTable = lazy( () => import( `../tables/FaqsTable.jsx` ) );
@@ -11,8 +13,6 @@ const FaqUrlsTable = lazy( () => import( `../tables/FaqUrlsTable.jsx` ) );
 
 export default function Faq() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
@@ -20,10 +20,19 @@ export default function Faq() {
 		[ 'faqurls', __( 'URL Assignment' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{ activeSection === 'overview' &&
 			<FaqsOverview moduleId={ moduleId } />
 			}

--- a/admin/src/modules/Generator.jsx
+++ b/admin/src/modules/Generator.jsx
@@ -1,4 +1,4 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
@@ -6,15 +6,15 @@ import GeneratorOverview from '../overview/Generator';
 import ModuleViewHeader from '../components/ModuleViewHeader';
 import ContentGeneratorPanel from '../components/generator/ContentGeneratorPanel';
 import GeneratorPromptTemplateTable from '../tables/GeneratorPromptTemplateTable';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const GeneratorResultTable = lazy( () => import( `../tables/GeneratorResultTable.jsx` ) );
 const GeneratorShortcodeTable = lazy( () => import( `../tables/GeneratorShortcodeTable.jsx` ) );
 
 export default function Generator() {
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
 	const { __ } = useI18n();
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
@@ -24,10 +24,19 @@ export default function Generator() {
 		[ 'result', __( 'Results' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<GeneratorOverview moduleId={ moduleId } />

--- a/admin/src/modules/ImageAltAttribute.jsx
+++ b/admin/src/modules/ImageAltAttribute.jsx
@@ -1,20 +1,26 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 
 import ImageAltAttributeOverview from '../overview/ImageAltAttribute';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
 export default function ImageAltAttribute() {
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
+
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+	] );
 
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 					<ImageAltAttributeOverview moduleId={ moduleId } />

--- a/admin/src/modules/KeywordsLinks.jsx
+++ b/admin/src/modules/KeywordsLinks.jsx
@@ -1,9 +1,11 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import KeywordLinksOverview from '../overview/KeywordsLinks';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const KeywordsTable = lazy( () => import( `../tables/KeywordsTable.jsx` ) );
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
@@ -11,13 +13,17 @@ const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
 export default function KeywordLinks() {
 	const { __ } = useI18n();
-	const slug = 'keyword';
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
+	const slug = 'keyword';
 
 	const tableMenu = new Map( [
 		[ slug, __( 'Links' ) ],
+	] );
+
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
 	] );
 
 	return (
@@ -25,7 +31,8 @@ export default function KeywordLinks() {
 			<ModuleViewHeader
 				moduleId={ moduleId }
 				moduleMenu={ tableMenu }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+				activeSection={ activeSection }
+			/>
 
 			{ activeSection === 'overview' &&
 			<KeywordLinksOverview moduleId={ moduleId } />

--- a/admin/src/modules/LazyLoading.jsx
+++ b/admin/src/modules/LazyLoading.jsx
@@ -1,9 +1,11 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import LazyLoadingOverview from '../overview/LazyLoading';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const YouTubeCacheTable = lazy( () => import( `../tables/YouTubeCacheTable.jsx` ) );
@@ -11,20 +13,25 @@ const ContentCacheTable = lazy( () => import( `../tables/ContentCacheTable.jsx` 
 
 export default function LazyLoading() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
 		[ 'youtube-cache', __( 'YouTube Videos' ) ],
 		[ 'content-cache', __( 'Content Lazy Loading' ) ],
-	]
-	);
+	] );
+
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
 
 	return (
 		<div className="urlslab-tableView">
 			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{ activeSection === 'overview' &&
 			<LazyLoadingOverview moduleId={ moduleId } />
 			}

--- a/admin/src/modules/LinkEnhancer.jsx
+++ b/admin/src/modules/LinkEnhancer.jsx
@@ -1,27 +1,36 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import LinkEnhancerOverview from '../overview/LinkEnhancer';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const LinkManagerTable = lazy( () => import( `../tables/LinkManagerTable.jsx` ) );
 
 export default function LinkEnhancer() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
 		[ 'url', __( 'URLs' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{ activeSection === 'overview' &&
 				<LinkEnhancerOverview moduleId={ moduleId } />
 			}

--- a/admin/src/modules/MediaOffloader.jsx
+++ b/admin/src/modules/MediaOffloader.jsx
@@ -1,28 +1,37 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import MediaOffloaderOverview from '../overview/MediaOffloader';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const MediaFilesTable = lazy( () => import( `../tables/MediaFilesTable.jsx` ) );
 
 export default function MediaOffloader() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-	const slug = 'file';
-
 	const { moduleId } = useOutletContext();
+	const slug = 'file';
 
 	const tableMenu = new Map( [
 		[ slug, __( 'Media Files' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{ activeSection === 'overview' &&
 			<MediaOffloaderOverview moduleId={ moduleId } />
 			}

--- a/admin/src/modules/MetaTag.jsx
+++ b/admin/src/modules/MetaTag.jsx
@@ -1,28 +1,37 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import MetaTagOverview from '../overview/MetaTag';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const MetaTagsTable = lazy( () => import( `../tables/MetaTagsTable.jsx` ) );
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
 export default function MetaTag() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-	const slug = 'metatag';
-
 	const { moduleId } = useOutletContext();
+	const slug = 'metatag';
 
 	const tableMenu = new Map( [
 		[ slug, __( 'Meta tags' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<MetaTagOverview moduleId={ moduleId } />

--- a/admin/src/modules/Optimize.jsx
+++ b/admin/src/modules/Optimize.jsx
@@ -1,20 +1,26 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 
 import OptimizeOverview from '../overview/Optimize';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
 export default function Optimize() {
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
+
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+	] );
 
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<OptimizeOverview moduleId={ moduleId } />

--- a/admin/src/modules/Redirects.jsx
+++ b/admin/src/modules/Redirects.jsx
@@ -1,9 +1,11 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import RedirectsOverview from '../overview/Redirects';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const NotFoundTable = lazy( () => import( `../tables/NotFoundTable.jsx` ) );
@@ -11,8 +13,6 @@ const RedirectsTable = lazy( () => import( `../tables/RedirectsTable.jsx` ) );
 
 export default function Redirects() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
@@ -20,10 +20,19 @@ export default function Redirects() {
 		[ 'notfound', __( '404 Monitor' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{ activeSection === 'overview' &&
 			<RedirectsOverview moduleId={ moduleId } />
 			}

--- a/admin/src/modules/RelatedResources.jsx
+++ b/admin/src/modules/RelatedResources.jsx
@@ -1,28 +1,37 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import RelatedResourcesOverview from '../overview/RelatedResources';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const URLRelationTable = lazy( () => import( `../tables/URLRelationTable.jsx` ) );
 
 export default function RelatedResources() {
 	const { __ } = useI18n();
-	const slug = 'url-relation';
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
+	const slug = 'url-relation';
 
 	const tableMenu = new Map( [
 		[ 'url-relation', __( 'Related Articles' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{ activeSection === 'overview' &&
 			<RelatedResourcesOverview moduleId={ moduleId } />
 			}

--- a/admin/src/modules/Screenshot.jsx
+++ b/admin/src/modules/Screenshot.jsx
@@ -1,27 +1,36 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import ScreenShotOverview from '../overview/Screenshot';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 const ScreenshotTable = lazy( () => import( `../tables/ScreenshotTable.jsx` ) );
 
 export default function Screenshot() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
 		[ 'screenshot', __( 'Screenshots' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
-			<ModuleViewHeader moduleId={ moduleId }
-				moduleMenu={ tableMenu } activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			<ModuleViewHeader
+				moduleId={ moduleId }
+				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 					<ScreenShotOverview moduleId={ moduleId } />

--- a/admin/src/modules/SearchAndReplace.jsx
+++ b/admin/src/modules/SearchAndReplace.jsx
@@ -1,30 +1,36 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import SearchAndReplaceOverview from '../overview/SearchAndReplace';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SearchReplaceTable = lazy( () => import( `../tables/SearchReplaceTable.jsx` ) );
 
 export default function SearchAndReplace() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
 	const slug = 'search-replace';
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
 		[ slug, __( 'Replacements' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
 			<ModuleViewHeader
 				moduleId={ moduleId }
-				noSettings
 				moduleMenu={ tableMenu }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+				activeSection={ activeSection }
+				noSettings
+			/>
 			{
 				activeSection === 'overview' &&
 				<SearchAndReplaceOverview moduleId={ moduleId } />

--- a/admin/src/modules/Serp.jsx
+++ b/admin/src/modules/Serp.jsx
@@ -1,9 +1,11 @@
-import { useState, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 
 import SerpOverview from '../overview/Serp';
 import ModuleViewHeader from '../components/ModuleViewHeader';
+import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../lib/helpers';
 
 const SettingsModule = lazy( () => import( `../modules/static/Settings.jsx` ) );
 const SerpQueriesTable = lazy( () => import( `../tables/SerpQueriesTable.jsx` ) );
@@ -15,8 +17,6 @@ const SerpGapTable = lazy( () => import( `../tables/SerpGapTable.jsx` ) );
 
 export default function Serp() {
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
-
 	const { moduleId } = useOutletContext();
 
 	const tableMenu = new Map( [
@@ -28,12 +28,19 @@ export default function Serp() {
 		[ 'serp-gap', __( 'Content Gap' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		'settings',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
 			<ModuleViewHeader
 				moduleId={ moduleId }
 				moduleMenu={ tableMenu }
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+				activeSection={ activeSection }
+			/>
 			{
 				activeSection === 'overview' &&
 				<SerpOverview moduleId={ moduleId } />

--- a/admin/src/modules/static/Schedule.jsx
+++ b/admin/src/modules/static/Schedule.jsx
@@ -26,7 +26,7 @@ export default function Schedule() {
 	const activeSection = useModuleSectionRoute( [
 		'overview',
 		...getMapKeysArray( tableMenu ),
-	] );
+	], moduleId );
 
 	return (
 		<div className="urlslab-tableView">

--- a/admin/src/modules/static/Schedule.jsx
+++ b/admin/src/modules/static/Schedule.jsx
@@ -1,17 +1,18 @@
-import { Suspense, lazy, useState } from 'react';
+import { Suspense, lazy } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 
 import SchedulesOverview from '../../overview/Schedules';
 import ModuleViewHeader from '../../components/ModuleViewHeader';
+import useModuleSectionRoute from '../../hooks/useModuleSectionRoute';
+import { getMapKeysArray } from '../../lib/helpers';
 
 const SchedulesTable = lazy( () => import( `../../tables/SchedulesTable.jsx` ) );
 const CreditsTable = lazy( () => import( `../../tables/CreditsTable.jsx` ) );
 const UsageTable = lazy( () => import( `../../tables/UsageTable.jsx` ) );
 
 export default function Schedule() {
-	const slug = 'schedule';
 	const { __ } = useI18n();
-	const [ activeSection, setActiveSection ] = useState( 'overview' );
+	const slug = 'schedule';
 
 	// define module id statically, this module is not included in api response to get value from query
 	const moduleId = 'urlslab-schedule';
@@ -22,13 +23,19 @@ export default function Schedule() {
 		[ 'credits', __( 'Recent Transactions' ) ],
 	] );
 
+	const activeSection = useModuleSectionRoute( [
+		'overview',
+		...getMapKeysArray( tableMenu ),
+	] );
+
 	return (
 		<div className="urlslab-tableView">
 			<ModuleViewHeader
 				moduleId={ moduleId }
 				moduleMenu={ tableMenu }
+				activeSection={ activeSection }
 				noSettings
-				activeMenu={ ( activemenu ) => setActiveSection( activemenu ) } />
+			/>
 			{ activeSection === 'overview' &&
 			<SchedulesOverview moduleId={ moduleId } />
 			}

--- a/admin/src/tables/SerpGapTable.jsx
+++ b/admin/src/tables/SerpGapTable.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable indent */
+import { Link } from 'react-router-dom';
 import { useI18n } from '@wordpress/react-i18n';
 import {
 	useInfiniteFetch,
@@ -13,8 +14,7 @@ import {
 } from '../lib/tableImports';
 
 import useTableUpdater from '../hooks/useTableUpdater';
-import { renameModule } from '../lib/helpers';
-import { Link } from 'react-router-dom';
+
 import useAIGenerator from '../hooks/useAIGenerator';
 import useModulesQuery from '../queries/useModulesQuery';
 import Button from '../elements/Button';
@@ -86,7 +86,7 @@ export default function SerpGapTable( { slug } ) {
 			tooltip: ( cell ) => <Tooltip>{ cell.getValue() }</Tooltip>,
 			cell: ( cell ) => isSuccessModules && modules[ 'urlslab-generator' ].active && ( <Link
 				onClick={ () => handleCreateContent( cell.row.original.query ) }
-				to={ '/' + renameModule( 'urlslab-generator' ) }
+				to="/Generator/generator"
 				className="urlslab-button active small"
 			>
 				{ __( 'Create Content' ) }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Modules sections in tabs are handled using react router.
Every tab has own route that can be used to access directly wanted module tab, ie. `/LinkEnhancer/settings`

**Testing instructions**
- app should still remember last visited tab
- last visited tab is opened only when direct module url is visited, ie. `/LinkEnhancer`
- if accessed tab route like `/LinkEnhancer/settings`, last visited tab is ignored
- non existing tab routes leads to Overview tab, ie. route like `/LinkEnhancer/xxxxxx` results to default Overview tab.

Close QualityUnit/web-issues#1864
