### PR TITLE
Date and time formats in pickers follow wp settings

### DIFF
--- a/admin/src/components/SettingsOption.jsx
+++ b/admin/src/components/SettingsOption.jsx
@@ -9,7 +9,7 @@ import { setSettings } from '../api/settings';
 import { getFetch } from '../api/fetching';
 import { setNotification } from '../hooks/useNotifications';
 
-import { parseURL, dateWithTimezone, is12hourFormat } from '../lib/helpers';
+import { parseURL, dateWithTimezone, getDateFnsFormat } from '../lib/helpers';
 import labelsList from '../lib/labelsList';
 
 import DatePicker from 'react-datepicker';
@@ -187,8 +187,9 @@ export default function SettingsOption( { settingId, option } ) {
 							className="urlslab-input xl"
 							selected={ date }
 							key={ id }
-							dateFormat={ `dd. MMMM yyyy, ${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
-							timeFormat={ `${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
+							dateFormat={ getDateFnsFormat().datetime }
+							timeFormat={ getDateFnsFormat().time }
+							calendarStartDay={ window.wp.date.getSettings().l10n.startOfWeek }
 							showTimeSelect
 							onChange={ ( val ) => {
 								const { origDate } = dateWithTimezone( val );

--- a/admin/src/components/TableFilterPanel.jsx
+++ b/admin/src/components/TableFilterPanel.jsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import Button from '@mui/joy/Button';
 
 import { stringOp, dateOp, numericOp, menuOp, langOp, tagsOp, booleanTypes } from '../lib/filterOperators';
-import { dateWithTimezone, is12hourFormat } from '../lib/helpers';
+import { dateWithTimezone, getDateFnsFormat } from '../lib/helpers';
 import { useFilter } from '../hooks/filteringSorting';
 import useTableStore from '../hooks/useTableStore';
 
@@ -206,8 +206,9 @@ export default function TableFilterPanel( { props, onEdit } ) {
 						<DatePicker
 							className="urlslab-input"
 							selected={ date }
-							dateFormat={ `dd. MMMM yyyy, ${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
-							timeFormat={ `${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
+							dateFormat={ getDateFnsFormat().datetime }
+							timeFormat={ getDateFnsFormat().time }
+							calendarStartDay={ window.wp.date.getSettings().l10n.startOfWeek }
 							showTimeSelect
 							onChange={ ( val ) => {
 								const { origDate, correctedDate } = dateWithTimezone( val );
@@ -224,8 +225,9 @@ export default function TableFilterPanel( { props, onEdit } ) {
 							<DatePicker
 								className="urlslab-input"
 								selected={ startDate }
-								dateFormat={ `dd. MMMM yyyy, ${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
-								timeFormat={ `${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
+								dateFormat={ getDateFnsFormat().datetime }
+								timeFormat={ getDateFnsFormat().time }
+								calendarStartDay={ window.wp.date.getSettings().l10n.startOfWeek }
 								showTimeSelect
 								selectsStart
 								startDate={ startDate }
@@ -243,8 +245,9 @@ export default function TableFilterPanel( { props, onEdit } ) {
 							<DatePicker
 								className="urlslab-input"
 								selected={ endDate }
-								dateFormat={ `dd. MMMM yyyy, ${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
-								timeFormat={ `${ is12hourFormat() ? 'hh:mm a' : 'HH:mm' }` }
+								dateFormat={ getDateFnsFormat().datetime }
+								timeFormat={ getDateFnsFormat().time }
+								calendarStartDay={ window.wp.date.getSettings().l10n.startOfWeek }
 								selectsEnd
 								showTimeSelect
 								startDate={ startDate }

--- a/admin/src/elements/DateRangeButton.jsx
+++ b/admin/src/elements/DateRangeButton.jsx
@@ -4,6 +4,8 @@ import 'react-date-range/dist/styles.css'; // main style file
 import 'react-date-range/dist/theme/default.css';
 import { DateRangePicker } from 'react-date-range';
 
+import { getDateFnsFormat } from '../lib/helpers';
+
 import Button from '@mui/joy/Button';
 
 import '../assets/styles/components/_DateRangePicker.scss';
@@ -52,6 +54,8 @@ function DateRangeButton( { startDate, endDate, className, handleSelect } ) {
 						direction="horizontal"
 						onChange={ onSelect }
 						maxDate={ new Date() }
+						dateDisplayFormat={ getDateFnsFormat().date }
+						weekStartsOn={ getSettings().l10n.startOfWeek }
 					/>
 				</div>
 			}

--- a/admin/src/lib/helpers.js
+++ b/admin/src/lib/helpers.js
@@ -71,6 +71,44 @@ export const is12hourFormat = ( ) => {
 	return false;
 };
 
+// get format in date-fns format for React DatePicker https://date-fns.org/docs/format
+export const getDateFnsFormat = () => {
+	const { getSettings } = window.wp.date;
+	const date = convertWpDatetimeFormatToDateFns( getSettings().formats.date );
+	const time = convertWpDatetimeFormatToDateFns( getSettings().formats.time );
+	return {
+		date,
+		time,
+		datetime: `${ date }, ${ time }`,
+	};
+};
+
+// convert Wordpress date/time format to date-fns format
+export const convertWpDatetimeFormatToDateFns = ( wpFormat ) => {
+	const formatMapping = {
+		d: 'dd',
+		D: 'EEE',
+		j: 'd',
+		l: 'EEEE',
+		F: 'MMMM',
+		m: 'MM',
+		M: 'MMM',
+		n: 'M',
+		Y: 'yyyy',
+		y: 'yy',
+		H: 'HH',
+		G: 'H',
+		h: 'hh',
+		g: 'h',
+		i: 'mm',
+		s: 'ss',
+		a: 'aaa',
+		A: 'aa',
+		T: 'zzzz',
+	};
+	return wpFormat.replace( /(d|D|j|l|F|m|M|n|Y|y|H|G|h|g|i|s|a|A|T)/g, ( match ) => formatMapping[ match ] || match );
+};
+
 export const parseURL = ( string ) => {
 	if ( string.length ) {
 		return string.replace( urlInTextRegex, '<a href="$1" target="_blank">$1</a>' );
@@ -134,3 +172,4 @@ export const textLinesToArray = ( value ) => {
 export const arrayToTextLines = ( value ) => {
 	return Array.isArray( value ) ? value.join( '\n' ) : '';
 };
+


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added conversion fn from wp format to format needed by datepickers.
Datapickers and DateRange picker show date and time in Wordpress format.
Also start of week defined in wp settings should be reflected in pickers.


**Testing instructions**
All datepickers have to use defined wp format and week start day.

Close QualityUnit/web-issues#1834
