### PR TITLE
fix: dropdowns overflow in table

### DIFF
--- a/admin/src/app/mui_joy/theme.js
+++ b/admin/src/app/mui_joy/theme.js
@@ -315,6 +315,13 @@ export const urlslabTheme = extendTheme( {
 							position: 'sticky',
 							left: 0,
 						},
+
+						'&:not(.has-scrollbar)': {
+							backgroundSize: 0,
+							'.urlslab-table': {
+								borderBottom: `1px solid ${ theme.vars.palette.divider }`,
+							},
+						},
 					} ),
 				} ),
 			},

--- a/admin/src/assets/styles/components/_TableComponent.scss
+++ b/admin/src/assets/styles/components/_TableComponent.scss
@@ -31,7 +31,8 @@ $cellHeight: 3.5em;
 		@include scrollbarWithBg();
 		// use max-height because of few rows tables
 		// prevent underlying wrapper and horizontal scrollbar moved to the bottom of screen
-		max-height: calc(100vh - var(--headerTopHeight) - var(--headerMenuHeight) - var(--headerBottomHeight) - var(--wp-admin--admin-bar--height, 32px));
+		// temporary used height again because of hidden dropdowns in few lines tables, will be used max-height again after mui dropdowns integration
+		height: calc(100vh - var(--headerTopHeight) - var(--headerMenuHeight) - var(--headerBottomHeight) - var(--wp-admin--admin-bar--height, 32px));
 		width: calc(var(--tableContainerWidth) - var(--urlslabmenuWidth));
 		overflow: auto;
 	}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Table wrapper height reverted back to fill maximum height as before to allow dropdowns overflow out of table.

Close QualityUnit/web-issues#2069
