### PR TITLE
2071: allow disable add new table record using parameter

### DIFF
--- a/admin/src/components/TableComponent.jsx
+++ b/admin/src/components/TableComponent.jsx
@@ -26,7 +26,7 @@ const getHeaderCellRealWidth = ( cell ) => {
 
 export const TableContext = createContext( {} );
 
-export default function Table( { resizable, children, className, columns, data, initialState, returnTable, closeableRowActions = false, referer } ) {
+export default function Table( { resizable, children, className, columns, data, initialState, returnTable, referer, closeableRowActions = false, disableAddNewTableRecord = false } ) {
 	const [ userCustomSettings, setUserCustomSettings ] = useState( {
 		columnVisibility: initialState?.columnVisibility || {},
 		openedRowActions: false,
@@ -198,7 +198,7 @@ export default function Table( { resizable, children, className, columns, data, 
 	}
 
 	if ( ! data?.length ) {
-		return <NoTable />;
+		return <NoTable disableAddNewTableRecord={ disableAddNewTableRecord } />;
 	}
 
 	return (
@@ -229,14 +229,16 @@ export default function Table( { resizable, children, className, columns, data, 
 	);
 }
 
-const NoTable = memo( () => {
+// disableAddNewTableRecord: disable add button, used for tables in table popup panel when we cannot reset global table store as main table still use it.
+const NoTable = memo( ( { disableAddNewTableRecord } ) => {
 	const title = useTableStore( ( state ) => state.title );
 	const filters = useTableStore( ( state ) => state.filters );
 	const hasFilters = Object.keys( filters ).length ? true : false;
+
 	return (
 		<div className="urlslab-table-fake">
 			<div className="urlslab-table-fake-inn">
-				{ title && ! hasFilters && <AddNewTableRecord title={ title } /> }
+				{ ( ! disableAddNewTableRecord && title && ! hasFilters ) && <AddNewTableRecord title={ title } /> }
 				{ hasFilters && <div className="bg-white p-m c-saturated-red">{ __( 'No items are matching your search or filter conditions.' ) }</div> }
 			</div>
 		</div>

--- a/admin/src/tables/SerpQueryDetailTopUrlsTable.jsx
+++ b/admin/src/tables/SerpQueryDetailTopUrlsTable.jsx
@@ -88,7 +88,7 @@ function SerpQueryDetailTopUrlsTable( { query, country, slug, handleClose } ) {
 	return (
 		<div>
 			<div className="urlslab-serpPanel-title">
-				<h4>Top URLs</h4>
+				<h4>{ __( 'Top URLs' ) }</h4>
 				<SingleSelectMenu defaultAccept autoClose key={ popupTableType } items={ {
 					A: __( 'All URLs' ),
 					M: __( 'My URLs' ),
@@ -101,6 +101,7 @@ function SerpQueryDetailTopUrlsTable( { query, country, slug, handleClose } ) {
 					slug="query/top-urls"
 					columns={ topUrlsCol }
 					data={ topUrlsSuccess && topUrls }
+					disableAddNewTableRecord
 				/>
 				}
 			</div> }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Removed Add Query button from missing table placeholder in SerpQueryDetailTopUrlsTable
Added ability to disable add new table record also via parameter in cases when we cannot reset global table store.

Close QualityUnit/web-issues#2071
