### PR TITLE
Refactor Prompt Template - redundant removal

### DIFF
--- a/admin/src/components/generator/manual/StepThird.jsx
+++ b/admin/src/components/generator/manual/StepThird.jsx
@@ -40,7 +40,7 @@ const StepThird = () => {
 	const { aiGeneratorConfig, setAIGeneratorConfig, aiGeneratorManualHelpers, setAIGeneratorManualHelpers } = useAIGenerator();
 	const { currentStep, setCurrentStep, steps, useEditor, noPromptTemplate, onGenerateComplete, isQuestionAnsweringGenerator } = useContext( ManualGeneratorContext );
 	const { data: aiModels, isSuccess: aiModelsSuccess, isFetching: isFetchingAiModels } = useAIModelsQuery();
-	const { data: allPromptTemplates, isSuccess: promptTemplatesSuccess, isFetching: isFetchingPromptTemplates } = usePromptTemplateQuery( isQuestionAnsweringGenerator ? 'A' : null );
+	const { data: allPromptTemplates, isSuccess: promptTemplatesSuccess, isFetching: isFetchingPromptTemplates } = usePromptTemplateQuery( isQuestionAnsweringGenerator ? 'A' : 'B' );
 
 	const [ stepState, setStepState ] = useState( {
 		promptVal: '',

--- a/admin/src/hooks/useAIGenerator.jsx
+++ b/admin/src/hooks/useAIGenerator.jsx
@@ -33,7 +33,7 @@ const fallbackData = {
 	inputValue: '', // input value for the generator
 	dataSource: 'NO_CONTEXT', // no datasource context selected by default
 	lang: 'en', // en lang by default
-	initialPromptType: 'G', // Initial Prompt Type selected
+	initialPromptType: 'B', // Initial Prompt Type selected - B for Blog Creation, A For Question Answering
 	title: '', // title of the created content - only applies in creating new post
 	postType: '', // post type of the created content - only applies in creating new post
 	urlsList: [], // list of urls to generate content from - only applies in URL_CONTEXT dataStore

--- a/admin/src/hooks/useAIGeneratorManualInit.jsx
+++ b/admin/src/hooks/useAIGeneratorManualInit.jsx
@@ -10,7 +10,7 @@ const useAIGeneratorManualInit = ( { initialData } ) => {
 	const { aiGeneratorConfig, setAIGeneratorConfig, setAIGeneratorManualHelpers } = useAIGenerator();
 
 	// preload queries to possibly show values inside related step immediately
-	usePromptTemplateQuery( initialData.initialPromptType ? initialData.initialPromptType : null );
+	usePromptTemplateQuery( initialData.initialPromptType ? initialData.initialPromptType : 'B' );
 	useAIModelsQuery();
 
 	useEffect( () => {

--- a/admin/src/hooks/useChangeRow.jsx
+++ b/admin/src/hooks/useChangeRow.jsx
@@ -40,8 +40,8 @@ export default function useChangeRow( customSlug ) {
 			return { response, updateAll };
 		},
 		onSuccess: async ( { response, updateAll } ) => {
-			const { ok } = await response;
-			if ( ok ) {
+			const rsp = await response;
+			if ( rsp.ok ) {
 				if ( updateAll ) {
 					queryClient.invalidateQueries( [ slug ] );
 				}
@@ -51,7 +51,17 @@ export default function useChangeRow( customSlug ) {
 				setNotification( slug, { message: 'Row has been added', status: 'success' } );
 				return false;
 			}
-			setNotification( slug, { message: 'Adding row failed', status: 'error' } );
+
+			if ( rsp.status === 400 ) {
+				try {
+					const errorRsp = await rsp.json();
+					setNotification( slug, { message: errorRsp.message, status: 'error' } );
+				} catch ( e ) {
+					setNotification( slug, { message: 'Adding row failed', status: 'error' } );
+				}
+			} else {
+				setNotification( slug, { message: 'Adding row failed', status: 'error' } );
+			}
 		},
 	} );
 	const insertRow = ( { editedRow, updateAll } ) => {

--- a/admin/src/queries/usePromptTemplateQuery.jsx
+++ b/admin/src/queries/usePromptTemplateQuery.jsx
@@ -5,7 +5,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { postFetch } from '../api/fetching';
 
-const usePromptTemplateQuery = ( prompt_type = null ) => {
+const usePromptTemplateQuery = ( prompt_type = 'B' ) => {
 	return useQuery( {
 		queryKey: [ 'prompt-template', prompt_type ],
 		queryFn: async () => {

--- a/admin/src/tables/GeneratorPromptTemplateTable.jsx
+++ b/admin/src/tables/GeneratorPromptTemplateTable.jsx
@@ -45,8 +45,6 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
 
 	const templateTypes = {
-		G: __( 'General' ),
-		S: __( 'Summarization' ),
 		B: __( 'Blog generation' ),
 		A: __( 'Question answering' ),
 	};
@@ -60,11 +58,9 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 	};
 
 	const rowEditorCells = {
-		template_name: <div>
-			<InputField liveUpdate defaultValue={ rowToEdit.template_name } label={ header.template_name }
-				description={ __( 'Prompt name for simple identification' ) }
-				onChange={ ( val ) => setRowToEdit( { ...rowToEdit, template_name: val } ) } required />
-		</div>,
+		template_name: <InputField defaultValue="" liveUpdate label={ header.template_name }
+			description={ __( 'Prompt name for simple identification' ) }
+			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, template_name: val } ) } required />,
 
 		prompt_template: <TextArea liveUpdate allowResize rows={ 15 }
 			description={ ( __( 'Prompt template used to generate text' ) ) }
@@ -74,7 +70,7 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 
 		model_name: <SingleSelectMenu autoClose defaultAccept description={ __( 'AI model used for the prompt' ) } items={ aiModelsSuccess ? aiModels : {} } defaultValue={ aiModelsSuccess ? Object.keys( aiModels )[ 0 ] : '' } name="model" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, model_name: val } ) }>{ header.model_name }</SingleSelectMenu>,
 
-		prompt_type: <SingleSelectMenu autoClose defaultAccept description={ __( 'Task type used for the prompt' ) } items={ templateTypes } defaultValue="G" name="prompt_type" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, prompt_type: val } ) }>{ header.prompt_type }</SingleSelectMenu>,
+		prompt_type: <SingleSelectMenu autoClose defaultAccept description={ __( 'Task type used for the prompt' ) } items={ templateTypes } defaultValue="B" name="prompt_type" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, prompt_type: val } ) }>{ header.prompt_type }</SingleSelectMenu>,
 	};
 
 	useEffect( () => {

--- a/includes/api/class-urlslab-api-prompt-template.php
+++ b/includes/api/class-urlslab-api-prompt-template.php
@@ -137,6 +137,20 @@ class Urlslab_Api_Prompt_Template extends Urlslab_Api_Table {
 		);
 	}
 
+	public function create_item( $request ) {
+		// prompt template validation
+		$prompt_type = $request->get_param( 'prompt_type' );
+		$prompt_template = $request->get_param( 'prompt_template' );
+
+		if ( Urlslab_Prompt_Template_Row::ANSWERING_TASK_PROMPT_TYPE === $prompt_type ) {
+			if ( ! str_contains( $prompt_template, '{question}' ) ) {
+				return new WP_REST_Response( array( 'message' => 'prompt_template must contain {question} variable' ), 400 );
+			}
+		}
+
+		return parent::create_item( $request );
+	}
+
 	protected function get_items_sql( WP_REST_Request $request ): Urlslab_Api_Table_Sql {
 		$sql = new Urlslab_Api_Table_Sql( $request );
 		$sql->add_select_column( '*' );

--- a/includes/class-urlslab-activator.php
+++ b/includes/class-urlslab-activator.php
@@ -422,6 +422,16 @@ class Urlslab_Activator {
 			}
 		);
 
+		self::update_step(
+			'2.65.0',
+			function() {
+				global $wpdb;
+				$wpdb->query('ALTER TABLE ' . URLSLAB_PROMPT_TEMPLATE_TABLE . " ALTER COLUMN prompt_type SET DEFAULT 'B'"); // phpcs:ignore
+				$wpdb->query( 'DELETE FROM' . URLSLAB_PROMPT_TEMPLATE_TABLE . " WHERE prompt_type = 'G' OR prompt_type = 'S'" ); // phpcs:ignore
+			}
+		);
+
+
 		// all update steps done, set the current version
 		update_option( URLSLAB_VERSION_SETTING, URLSLAB_VERSION );
 	}
@@ -889,7 +899,7 @@ class Urlslab_Activator {
 							template_name varchar(100) NOT NULL,    
     						model_name varchar(100) NOT NULL,
     						prompt_template TEXT NOT NULL,
-    						prompt_type char(1) NOT NULL DEFAULT 'G', -- S = Summarization Task, A = Question Answering, G = General Task
+    						prompt_type char(1) NOT NULL DEFAULT 'B', -- A = Question Answering, B = Blog Creation
 							updated DATETIME,
 							PRIMARY KEY  (template_id)
 							) {$charset_collate};";

--- a/includes/data/class-urlslab-prompt-template-row.php
+++ b/includes/data/class-urlslab-prompt-template-row.php
@@ -2,9 +2,7 @@
 
 class Urlslab_Prompt_Template_Row extends Urlslab_Data {
 
-	public const GENERAL_TASK_PROMPT_TYPE = 'G';
 	public const BLOG_CREATION_TASK_PROMPT_TYPE = 'B';
-	public const SUMMARIZATION_TASK_PROMPT_TYPE = 'S';
 	public const ANSWERING_TASK_PROMPT_TYPE = 'A';
 
 	public function __construct( array $data = array(), $loaded_from_db = true ) {
@@ -13,7 +11,7 @@ class Urlslab_Prompt_Template_Row extends Urlslab_Data {
 		$this->set_model_name( $data['model_name'] ?? '', $loaded_from_db );
 		$this->set_prompt_template( $data['prompt_template'] ?? '', $loaded_from_db );
 		$this->set_updated( empty( $data['updated'] ) ? self::get_now() : $data['updated'], $loaded_from_db );
-		$this->set_prompt_type( $data['prompt_type'] ?? self::GENERAL_TASK_PROMPT_TYPE, $loaded_from_db );
+		$this->set_prompt_type( $data['prompt_type'] ?? self::BLOG_CREATION_TASK_PROMPT_TYPE, $loaded_from_db );
 	}
 
 	public function set_template_id( int $template_id, $loaded_from_db = false ) {

--- a/includes/defaults/class-urlslab-default-prompt-template.php
+++ b/includes/defaults/class-urlslab-default-prompt-template.php
@@ -6,12 +6,6 @@ class Urlslab_Default_Prompt_Template {
 
 	private static $initial_data = array(
 		array(
-			'template_name' => 'Summarization',
-			'model_name' => DomainDataRetrievalAugmentRequest::AUGMENTING_MODEL_NAME_GPT_3_5_TURBO,
-			'prompt_template' => "Summarize the following context:\n\n{context}\n\nSummary:\n\n",
-			'prompt_type' => Urlslab_Prompt_Template_Row::SUMMARIZATION_TASK_PROMPT_TYPE,
-		),
-		array(
 			'template_name' => 'Question Answering',
 			'model_name' => DomainDataRetrievalAugmentRequest::AUGMENTING_MODEL_NAME_GPT_3_5_TURBO,
 			'prompt_template' => "Answer the following QUESTION based on the CONTEXT:\n\nCONTEXT:\n\n{context}\nQUESTION:\n\n{question}\n\nAnswer:",

--- a/urlslab.php
+++ b/urlslab.php
@@ -16,7 +16,7 @@
  * Plugin Name:       URLsLab
  * Plugin URI:        https://github.com/QualityUnit/wp-urlslab
  * Description:       URLsLab WordPress Plugin to optimize your website for search engines and enhance automatically content
- * Version: 2.64.1
+ * Version: 2.65.0
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            URLsLab
@@ -30,7 +30,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'URLSLAB_VERSION', '2.64.1' );
+define( 'URLSLAB_VERSION', '2.65.0' );
 define( 'URLSLAB_VERSION_SETTING', 'urlslab_ver' );
 define( 'URLSLAB_PLUGIN', __FILE__ );
 


### PR DESCRIPTION
Remove Prompt Template type General. (Now just Using two Prompt Template types Blog Creation and Question Answering)
Using only Blog Creation in the AI Generator Section
Using only Question answering in FAQ
Added Proper Validation

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
