### PR TITLE
fix: improved speed of competitors tab and added description

### DIFF
--- a/admin/src/tables/SerpCompetitorsTable.jsx
+++ b/admin/src/tables/SerpCompetitorsTable.jsx
@@ -33,10 +33,10 @@ export default function SerpCompetitorsTable( { slug } ) {
 
 	const header = {
 		domain_name: __( 'Domain' ),
-		avg_position: __( 'Avg. position' ),
+		urls_cnt: __( 'Intersected URLs' ),
 		coverage: __( 'Coverage (%)' ),
-		cnt_top10_intersections: __( 'Top 10 intersections' ),
-		cnt_top100_intersections: __( 'Top 100 intersections' ),
+		top10_queries_cnt: __( 'Top 10 queries' ),
+		top100_queries_cnt: __( 'Top 100 queries' ),
 	};
 
 	useEffect( () => {
@@ -79,7 +79,7 @@ export default function SerpCompetitorsTable( { slug } ) {
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 200,
 		} ),
-		columnHelper.accessor( 'avg_position', {
+		columnHelper.accessor( 'urls_cnt', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <strong>{ cell.getValue() }</strong>,
 			header: ( th ) => <SortBy { ...th } />,
@@ -91,13 +91,13 @@ export default function SerpCompetitorsTable( { slug } ) {
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 50,
 		} ),
-		columnHelper.accessor( 'cnt_top10_intersections', {
+		columnHelper.accessor( 'top10_queries_cnt', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <strong>{ cell.getValue() }</strong>,
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 50,
 		} ),
-		columnHelper.accessor( 'cnt_top100_intersections', {
+		columnHelper.accessor( 'top100_queries_cnt', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <strong>{ cell.getValue() }</strong>,
 			header: ( th ) => <SortBy { ...th } />,
@@ -111,6 +111,12 @@ export default function SerpCompetitorsTable( { slug } ) {
 
 	return (
 		<>
+			<div className="urlslab-serpPanel-title">
+				<div className="urlslab-serpPanel-description">
+					<h4>Report Methodology</h4>
+					<p>Compare your domain with domains of your competitors. Assign domain type to domains in the "Domains" tab first. Only URLs from each domain that overlap with certain queries from competitors are taken into consideration. We believe that only URLs ranking for the same queries as your competitors are pertinent to each domain. A domain's coverage is the sum of URLs in the top ten rankings, divided by the number of queries in the top ten rankings for all URLs found in our database. Please note that only URLs discovered during SERP query processing are counted. The more queries you authorize for processing in your settings, the more accurate your domain comparison data will be.</p>
+				</div>
+			</div>
 			<ModuleViewHeaderBottom
 				noDelete
 				noInsert

--- a/includes/api/class-urlslab-api-serp-competitors.php
+++ b/includes/api/class-urlslab-api-serp-competitors.php
@@ -27,25 +27,29 @@ class Urlslab_Api_Serp_Competitors extends Urlslab_Api_Table {
 			$sql->add_select_column( $column, 'd' );
 		}
 
-		$sql->add_select_column( 'COUNT(*)', false, 'cnt_top100_intersections' );
-		$sql->add_select_column( 'SUM(CASE WHEN p.position < 11 AND pm.position < 11 THEN 1 ELSE 0 END)', false, 'cnt_top10_intersections' );
-		$sql->add_select_column( 'AVG( p.position )', false, 'avg_position' );
-		$sql->add_select_column( '(SUM(p.position) / (SELECT SUM(p.position) FROM ' . URLSLAB_SERP_DOMAINS_TABLE . ' d INNER JOIN ' . URLSLAB_SERP_POSITIONS_TABLE . ' p ON p.domain_id=d.domain_id INNER JOIN ' . URLSLAB_SERP_POSITIONS_TABLE . ' pm ON pm.query_id=p.query_id AND pm.domain_id IN (SELECT domain_id FROM ' . URLSLAB_SERP_DOMAINS_TABLE . " WHERE domain_type='" . Urlslab_Serp_Domain_Row::TYPE_MY_DOMAIN . "') WHERE d.domain_type = '" . Urlslab_Serp_Domain_Row::TYPE_COMPETITOR . "')) * 100", false, 'coverage', false );
+		$sql->add_select_column( 'COUNT(*)', false, 'urls_cnt' );
+		$sql->add_select_column( 'SUM(u.top10_queries_cnt)', false, 'top10_queries_cnt' );
+		$sql->add_select_column( 'SUM(u.top100_queries_cnt)', false, 'top100_queries_cnt' );
+		$sql->add_select_column( '(SUM(u.top10_queries_cnt) / ( SELECT SUM(u.top10_queries_cnt) FROM ' . URLSLAB_SERP_DOMAINS_TABLE . ' d INNER JOIN ' . URLSLAB_SERP_URLS_TABLE . " u ON d.domain_id=u.domain_id AND u.comp_intersections>3 WHERE d.domain_type IN ('" . Urlslab_Serp_Domain_Row::TYPE_COMPETITOR . "','" . Urlslab_Serp_Domain_Row::TYPE_MY_DOMAIN . "')))*100", false, 'coverage', false );
 
 		$sql->add_from( URLSLAB_SERP_DOMAINS_TABLE . ' d' );
+		$sql->add_from('INNER JOIN ' . URLSLAB_SERP_URLS_TABLE . ' u ON d.domain_id=u.domain_id AND u.comp_intersections>=2');
+		$sql->add_filter_str('(');
+		$sql->add_filter_str('d.domain_type IN (%s, %s)');
+		$sql->add_query_data( Urlslab_Serp_Domain_Row::TYPE_COMPETITOR );
+		$sql->add_query_data( Urlslab_Serp_Domain_Row::TYPE_MY_DOMAIN );
+		$sql->add_filter_str(')');
 
-		$sql->add_from( 'INNER JOIN ' . URLSLAB_SERP_POSITIONS_TABLE . " p ON p.domain_id=d.domain_id AND d.domain_type='" . Urlslab_Serp_Domain_Row::TYPE_COMPETITOR . "'" );
-		$sql->add_from( 'INNER JOIN ' . URLSLAB_SERP_POSITIONS_TABLE . ' pm ON pm.query_id=p.query_id AND pm.domain_id IN (SELECT domain_id FROM ' . URLSLAB_SERP_DOMAINS_TABLE . " WHERE domain_type='" . Urlslab_Serp_Domain_Row::TYPE_MY_DOMAIN . "')" );
 
 		$columns = $this->prepare_columns( $this->get_row_object()->get_columns(), 'd' );
 		$columns = array_merge(
 			$columns,
 			$this->prepare_columns(
 				array(
-					'cnt_top10_intersections' => '%d',
-					'cnt_top100_intersections' => '%d',
-					'avg_position'   => '%s',
+					'top10_queries_cnt' => '%d',
+					'top100_queries_cnt' => '%d',
 					'coverage'       => '%d',
+					'urls_cnt'       => '%d',
 				)
 			)
 		);
@@ -53,6 +57,7 @@ class Urlslab_Api_Serp_Competitors extends Urlslab_Api_Table {
 		$sql->add_group_by( 'domain_id', 'd' );
 		$sql->add_having_filters( $columns, $request );
 		$sql->add_sorting( $columns, $request );
+
 
 		return $sql;
 	}
@@ -71,9 +76,9 @@ class Urlslab_Api_Serp_Competitors extends Urlslab_Api_Table {
 
 		foreach ( $rows as $row ) {
 			$row->domain_id = (int) $row->domain_id;
-			$row->cnt_top10_intersections = (int) $row->cnt_top10_intersections;
-			$row->cnt_top100_intersections = (int) $row->cnt_top100_intersections;
-			$row->avg_position = round( (float) $row->avg_position, 1 );
+			$row->top10_queries_cnt = (int) $row->top10_queries_cnt;
+			$row->top100_queries_cnt = (int) $row->top100_queries_cnt;
+			$row->urls_cnt = (int) $row->urls_cnt;
 			$row->coverage = round( (float) $row->coverage, 2 );
 		}
 


### PR DESCRIPTION
TODO: @ihdk can you add nice design for table description in SERP Monitoring -> Competitors tab?

I want to add similar description nearly to each table, because users will not know how to use these tables

![Screenshot from 2023-10-08 18-56-25](https://github.com/QualityUnit/wp-urlslab/assets/6470030/3b91d310-bd04-4db3-a446-322d30f58d95)

