### PR TITLE
fix: missing table actions button

### DIFF
--- a/admin/src/components/ModuleViewHeaderBottom.jsx
+++ b/admin/src/components/ModuleViewHeaderBottom.jsx
@@ -104,7 +104,7 @@ export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hi
 						{ ! noCount &&
 						<RowCounter />
 						}
-						{ hideActions &&
+						{ ! hideActions &&
 							<TableActionsMenu options={ { noImport, noExport, noDelete } } />
 						}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed condition to show `TableActionsMenu` component above tables.
