### PR TITLE
Bugfixes: #2138 #2133

### DIFF
--- a/admin/src/hooks/useFilteringSorting.jsx
+++ b/admin/src/hooks/useFilteringSorting.jsx
@@ -73,11 +73,6 @@ export function useFilter( customSlug ) {
 			return 'date';
 		}
 
-		if ( ! isNaN( initialRow?.original[ key ] ) ) {
-			dispatch( { type: 'setKeyType', keyType: 'number' } );
-			return 'number';
-		}
-
 		if ( key?.includes( 'lang' ) ) {
 			dispatch( { type: 'setKeyType', keyType: 'lang' } );
 			return 'lang';
@@ -86,6 +81,11 @@ export function useFilter( customSlug ) {
 		if ( key === 'labels' ) {
 			dispatch( { type: 'setKeyType', keyType: 'labels' } );
 			return 'labels';
+		}
+
+		if ( ! isNaN( initialRow?.original[ key ] ) ) {
+			dispatch( { type: 'setKeyType', keyType: 'number' } );
+			return 'number';
 		}
 
 		if ( typeof initialRow?.original[ key ] === 'boolean' ) {

--- a/admin/src/lib/helpers.js
+++ b/admin/src/lib/helpers.js
@@ -173,3 +173,7 @@ export const arrayToTextLines = ( value ) => {
 	return Array.isArray( value ) ? value.join( '\n' ) : '';
 };
 
+export const urlHasProtocol = ( value ) => {
+	const protocolRegex = /^https?:\/\//i;
+	return protocolRegex.test( value );
+};

--- a/admin/src/tables/SerpCompetitorsTable.jsx
+++ b/admin/src/tables/SerpCompetitorsTable.jsx
@@ -11,6 +11,7 @@ import {
 	ModuleViewHeaderBottom,
 	TooltipSortingFiltering,
 } from '../lib/tableImports';
+import { urlHasProtocol } from '../lib/helpers';
 
 import useTableStore from '../hooks/useTableStore';
 import useTablePanels from '../hooks/useTablePanels';
@@ -77,7 +78,7 @@ export default function SerpCompetitorsTable( { slug } ) {
 	const columns = [
 		columnHelper.accessor( 'domain_name', {
 			tooltip: ( cell ) => cell.getValue(),
-			cell: ( cell ) => <a href={ cell.getValue() } target="_blank" rel="noreferrer"><strong>{ cell.getValue() }</strong></a>,
+			cell: ( cell ) => <a href={ urlHasProtocol( cell.getValue() ) ? cell.getValue() : `http://${ cell.getValue() }` } target="_blank" rel="noreferrer"><strong>{ cell.getValue() }</strong></a>,
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 200,
 		} ),


### PR DESCRIPTION
**Changes proposed in this Pull Request**
#2138:
Fixed tags in table filter.
As type of input for selected column is recognized from first row cells, if first row doesn't include any tags, this cell was considered as `number` cell.

Conditions that check exactly for key name in conditions hierarchy were moved early before checking for number cell.
`if ( ! isNaN( initialRow?.original[ key ] )` condition for empty tags cell was considered as `number` and returned this type early.

#2133:
added checking for protocol in domains, in Serp Monitoring Competitors > Domains column.
as values can be any strings, if there is no protocol in cell value, added is simply https to make correct links

Close QualityUnit/web-issues#2138
Close QualityUnit/web-issues#2133
