### PR TITLE
fix: tables rerenders from table panels

### DIFF
--- a/admin/src/app/mui_joy/themes/buttonTheme.js
+++ b/admin/src/app/mui_joy/themes/buttonTheme.js
@@ -51,6 +51,13 @@ const buttonTheme = {
 					paddingInline: '0.5rem',
 				} ),
 
+				// apply custom margin classes styles
+				'&.ml-s': {
+					marginLeft: theme.spacing( 1 ),
+				},
+				'&.mr-s': {
+					marginRight: theme.spacing( 1 ),
+				},
 			} ),
 			// styles for our custom svg icons, mui icon components already include following styling
 			startDecorator: {

--- a/admin/src/components/EditRowPanel.jsx
+++ b/admin/src/components/EditRowPanel.jsx
@@ -22,6 +22,8 @@ function EditRowPanel( { editorMode, noScrollbar, notWide, text } ) {
 	const rowEditorCells = useTablePanels( ( state ) => state.rowEditorCells );
 	const panelOverflow = useTablePanels( ( state ) => state.panelOverflow );
 	const showSecondPanel = useTablePanels( ( state ) => state.showSecondPanel );
+	const customSubmitAction = useTablePanels( ( state ) => state.customSubmitAction );
+
 	const { insertRow, saveEditedRow } = useChangeRow( );
 
 	const requiredFields = rowEditorCells && Object.keys( rowEditorCells ).filter( ( cell ) => rowEditorCells[ cell ]?.props.required === true );
@@ -69,7 +71,13 @@ function EditRowPanel( { editorMode, noScrollbar, notWide, text } ) {
 	function hidePanel( response ) {
 		handleClose();
 		showSecondPanel();
-		useTablePanels.setState( { rowToEdit: {} } ); // Resetting state on updating/adding row
+
+		// Resetting states on updating/adding row
+		useTablePanels.setState( {
+			rowToEdit: {},
+			customSubmitAction: null,
+		} );
+
 		rowToEditWithDefaults = {};
 		enableAddButton.current = false;
 		if ( response ) {
@@ -88,6 +96,11 @@ function EditRowPanel( { editorMode, noScrollbar, notWide, text } ) {
 			return false;
 		}
 		insertRow( { editedRow: rowToEditWithDefaults } );
+		hidePanel( 'rowInserted' );
+	}
+
+	function handleCustomAction() {
+		customSubmitAction();
 		hidePanel( 'rowInserted' );
 	}
 
@@ -116,7 +129,7 @@ function EditRowPanel( { editorMode, noScrollbar, notWide, text } ) {
 				</div>
 				<div className="flex ">
 					<Button variant="plain" color="neutral" onClick={ hidePanel } sx={ { ml: 'auto', mr: 1 } }>{ __( 'Cancel' ) }</Button>
-					<Button disabled={ ! enableAddButton.current } onClick={ handleEdit }>
+					<Button disabled={ ! enableAddButton.current } onClick={ customSubmitAction ? handleCustomAction : handleEdit }>
 						{ editorMode
 							? __( 'Save changes' )
 							: title

--- a/admin/src/components/ModuleViewHeaderBottom.jsx
+++ b/admin/src/components/ModuleViewHeaderBottom.jsx
@@ -50,7 +50,8 @@ export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hi
 
 	const close = useCallback( () => {
 		dispatch( { type: 'toggleEditFilter', editFilter: false } );
-	}, [] );
+	}, [ dispatch ] );
+
 	useClickOutside( panelPopover, close );
 
 	const handleOnEdit = useCallback( ( returnObj ) => {
@@ -64,9 +65,8 @@ export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hi
 
 	useEffect( () => {
 		handleHeaderHeight();
-
 		didMountRef.current = true;
-	}, [ ] );
+	}, [ handleHeaderHeight ] );
 
 	return (
 		<>

--- a/admin/src/components/TableComponent.jsx
+++ b/admin/src/components/TableComponent.jsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState, useEffect, memo, createContext } from 'react';
+import { useRef, useCallback, useState, useEffect, memo, createContext, useMemo } from 'react';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { get, update } from 'idb-keyval';
@@ -93,7 +93,7 @@ export default function Table( { resizable, children, className, columns, data, 
 	}
 
 	const table = useReactTable( {
-		columns,
+		columns: useMemo( () => columns, [ columns ] ),
 		data,
 		defaultColumn: {
 			minSize: resizable ? 80 : 32,
@@ -150,7 +150,7 @@ export default function Table( { resizable, children, className, columns, data, 
 			}
 		} );
 		resizeWatcher.observe( document.documentElement );
-	}, [ slug, table, rowSelection, checkTableOverflow, getUserCustomSettings ] );
+	}, [ slug, table, rowSelection, checkTableOverflow, getUserCustomSettings, data?.length ] );
 
 	// Defines table data when no data were initially loaded (ie Content Gap generator)
 	useEffect( () => {

--- a/admin/src/components/TableHead.jsx
+++ b/admin/src/components/TableHead.jsx
@@ -68,7 +68,7 @@ const TableHead = () => {
 				}
 			}
 		}
-	}, [ closeableRowActions, userCustomSettings.columnVisibility ] );
+	}, [ closeableRowActions, tableContainerRef, userCustomSettings.columnVisibility ] );
 
 	return (
 		<thead className="urlslab-table-head">

--- a/admin/src/components/TablePanels.jsx
+++ b/admin/src/components/TablePanels.jsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 
 import useTablePanels from '../hooks/useTablePanels';
@@ -14,10 +15,11 @@ import DetailsPanel from './DetailsPanel';
 import SvgIcon from '../elements/SvgIcon';
 import ChangesPanel from './ChangesPanel/ChangesPanel';
 
-export default function TablePanels( { props } ) {
-	const { options } = props;
-	const { activePanel } = useTablePanels();
+function TablePanels( { props } ) {
 	const { __ } = useI18n();
+	const activePanel = useTablePanels( ( state ) => state.activePanel );
+	const { options } = props;
+
 	return (
 		<>
 			{
@@ -83,3 +85,5 @@ export default function TablePanels( { props } ) {
 		</>
 	);
 }
+
+export default memo( TablePanels );

--- a/admin/src/hooks/useCloseModal.jsx
+++ b/admin/src/hooks/useCloseModal.jsx
@@ -25,7 +25,7 @@ export default function useCloseModal( ) {
 		} );
 	}, [ handleClose ] );
 
-	if ( activePanel ) {
+	if ( activePanel !== undefined ) {
 		document.querySelector( '#urlslab-root' ).classList.add( 'dark' );
 		document.querySelector( 'body' ).classList.add( 'noscroll' );
 	}

--- a/admin/src/hooks/useRedirectTableMenus.jsx
+++ b/admin/src/hooks/useRedirectTableMenus.jsx
@@ -1,35 +1,35 @@
-import { useI18n } from '@wordpress/react-i18n';
+import { useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 
 export default function useRedirectTableMenus() {
-	const { __ } = useI18n();
-
-	const redirectTypes = Object.freeze( {
+	// memoized objects to safely use them as dependency in effects
+	const redirectTypes = useMemo( () => Object.freeze( {
 		301: '301 Moved Permanently',
 		302: '302 Found, Moved temporarily',
 		303: '303 See Other',
 		307: '307 Temporary Redirect',
 		308: '308 Permanent Redirect',
-	} );
+	} ), [] );
 
-	const matchTypes = Object.freeze( {
+	const matchTypes = useMemo( () => Object.freeze( {
 		E: 'Exact match',
 		S: 'Contains',
 		R: 'Regular expression',
-	} );
+	} ), [] );
 
-	const logginTypes = Object.freeze( {
+	const logginTypes = useMemo( () => Object.freeze( {
 		Y: 'Logged in',
 		N: 'Not logged in',
 		A: 'Any',
-	} );
+	} ), [] );
 
-	const notFoundTypes = Object.freeze( {
+	const notFoundTypes = useMemo( () => Object.freeze( {
 		Y: 'Page not found',
 		N: 'Page found',
 		A: 'Any',
-	} );
+	} ), [] );
 
-	const header = Object.freeze( {
+	const header = useMemo( () => Object.freeze( {
 		match_type: __( 'Match type' ),
 		match_url: __( 'URL' ),
 		replace_url: __( 'Redirect to' ),
@@ -46,7 +46,7 @@ export default function useRedirectTableMenus() {
 		cnt: __( 'Redirects count' ),
 		labels: __( 'Tags' ),
 		created: __( 'Created' ),
-	} );
+	} ), [] );
 
 	return { redirectTypes, matchTypes, logginTypes, notFoundTypes, header };
 }

--- a/admin/src/hooks/useTablePanels.jsx
+++ b/admin/src/hooks/useTablePanels.jsx
@@ -6,6 +6,7 @@ const initialState = {
 	rowEditorCells: {},
 	deleteCSVCols: [],
 	panelOverflow: false,
+	customSubmitAction: null,
 };
 
 const useTablePanels = create( ( set ) => ( {

--- a/admin/src/tables/CSSCacheTable.jsx
+++ b/admin/src/tables/CSSCacheTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch, ProgressBar, SortBy, Tooltip, Checkbox, Loader, Table, ModuleViewHeaderBottom, TooltipSortingFiltering, DateTimeFormat, IconButton, SvgIcon, RowActionButtons,
@@ -9,10 +9,23 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTableStore from '../hooks/useTableStore';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function CSSCacheTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'url_id';
+const paginationId = 'url_id';
 
+const statusTypes = {
+	N: __( 'New' ),
+	A: __( 'Available' ),
+	P: __( 'Processing' ),
+	D: __( 'Disabled' ),
+};
+
+const header = {
+	url: __( 'URL' ),
+	filesize: __( 'File size' ),
+	status: __( 'Status' ),
+	status_changed: __( 'Last change' ),
+};
+
+export default function CSSCacheTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -25,7 +38,7 @@ export default function CSSCacheTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const ActionButton = ( { cell, onClick } ) => {
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
 		const { status: cssStatus } = cell?.row?.original;
 
 		return (
@@ -40,21 +53,7 @@ export default function CSSCacheTable( { slug } ) {
 				}
 			</div>
 		);
-	};
-
-	const statusTypes = {
-		N: __( 'New' ),
-		A: __( 'Available' ),
-		P: __( 'Processing' ),
-		D: __( 'Disabled' ),
-	};
-
-	const header = {
-		url: __( 'URL' ),
-		filesize: __( 'File size' ),
-		status: __( 'Status' ),
-		status_changed: __( 'Last change' ),
-	};
+	}, [] );
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -72,16 +71,21 @@ export default function CSSCacheTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -123,7 +127,7 @@ export default function CSSCacheTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, selectRows, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/ContentCacheTable.jsx
+++ b/admin/src/tables/ContentCacheTable.jsx
@@ -1,15 +1,21 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 import {
 	useInfiniteFetch, ProgressBar, SortBy, Loader, Table, ModuleViewHeaderBottom, TooltipSortingFiltering, DateTimeFormat,
 } from '../lib/tableImports';
 import useTableStore from '../hooks/useTableStore';
+
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function ContentCacheTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'cache_crc32';
+const paginationId = 'cache_crc32';
 
+const header = {
+	cache_content: __( 'Cache content' ),
+	cache_len: __( 'Cache size' ),
+	date_changed: __( 'Last change' ),
+};
+
+export default function ContentCacheTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -19,12 +25,6 @@ export default function ContentCacheTable( { slug } ) {
 		hasNextPage,
 		ref,
 	} = useInfiniteFetch( { slug } );
-
-	const header = {
-		cache_content: __( 'Cache content' ),
-		cache_len: __( 'Cache size' ),
-		date_changed: __( 'Last change' ),
-	};
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -42,16 +42,24 @@ export default function ContentCacheTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+						paginationId,
+						slug,
+						header,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'cache_content', {
 			tooltip: ( cell ) => cell.getValue(),
 			header: ( th ) => <SortBy { ...th } />,
@@ -67,7 +75,7 @@ export default function ContentCacheTable( { slug } ) {
 			header: ( th ) => <SortBy { ...th } />,
 			size: 115,
 		} ),
-	];
+	], [ columnHelper ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/CreditsTable.jsx
+++ b/admin/src/tables/CreditsTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 import {
 	useInfiniteFetch,
 	Loader,
@@ -14,24 +14,23 @@ import DescriptionBox from '../elements/DescriptionBox';
 
 import '../assets/styles/components/_ModuleViewHeader.scss';
 
-export default function CreditsTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'id';
+const paginationId = 'id';
 
+const header = {
+	id: __( 'Transaction ID' ),
+	operationDate: __( 'Timestamp' ),
+	creditType: __( 'Type' ),
+	creditOperation: __( 'Operation' ),
+	context: __( 'Data' ),
+};
+
+export default function CreditsTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
 		status,
 		isSuccess,
 	} = useInfiniteFetch( { slug } );
-
-	const header = {
-		id: __( 'Transaction ID' ),
-		operationDate: __( 'Timestamp' ),
-		creditType: __( 'Type' ),
-		creditOperation: __( 'Operation' ),
-		context: __( 'Data' ),
-	};
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -49,16 +48,21 @@ export default function CreditsTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'id', {
 			header: header.id,
 			size: 60,
@@ -82,7 +86,7 @@ export default function CreditsTable( { slug } ) {
 			header: header.context,
 			size: 200,
 		} ),
-	];
+	], [ columnHelper ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/CustomHtmlTable.jsx
+++ b/admin/src/tables/CustomHtmlTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch,
@@ -22,11 +22,49 @@ import useTablePanels from '../hooks/useTablePanels';
 import useTableStore from '../hooks/useTableStore';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function CustomHtmlTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add Custom Code' );
-	const paginationId = 'rule_id';
+const title = __( 'Add Custom Code' );
+const paginationId = 'rule_id';
 
+const matchTypes = Object.freeze( {
+	A: 'All pages',
+	E: 'Exact match',
+	S: 'Contains',
+	R: 'Regular expression',
+} );
+
+const logginTypes = Object.freeze( {
+	Y: 'Logged in',
+	N: 'Not logged in',
+	A: 'Any',
+} );
+
+const header = {
+	name: __( 'Rule name' ),
+	is_active: __( 'Active rule' ),
+	labels: __( 'Tags' ),
+
+};
+
+const editRowCells = {
+	match_type: __( 'Match type' ),
+	match_url: __( 'Match URL' ),
+	rule_order: __( 'Order' ),
+	match_headers: __( 'Request headers' ),
+	match_cookie: __( 'Cookies' ),
+	match_params: __( 'Request parameters' ),
+	match_capabilities: __( 'Capabilities' ),
+	match_ip: __( 'Visitor IP' ),
+	match_roles: __( 'Roles' ),
+	match_browser: __( 'Browser' ),
+	is_logged: __( 'Is logged in' ),
+	add_http_headers: __( 'Custom HTTP Headers' ),
+	add_start_headers: __( 'After <head>' ),
+	add_end_headers: __( 'Before </head>' ),
+	add_start_body: __( 'After <body>`' ),
+	add_end_body: __( 'Before `</body>`' ),
+};
+
+export default function CustomHtmlTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -39,134 +77,13 @@ export default function CustomHtmlTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-
-	const matchTypes = Object.freeze( {
-		A: 'All pages',
-		E: 'Exact match',
-		S: 'Contains',
-		R: 'Regular expression',
-	} );
-
-	const logginTypes = Object.freeze( {
-		Y: 'Logged in',
-		N: 'Not logged in',
-		A: 'Any',
-	} );
-
-	const header = {
-		name: __( 'Rule name' ),
-		is_active: __( 'Active rule' ),
-		labels: __( 'Tags' ),
-
-	};
-
-	const editRowCells = {
-		match_type: __( 'Match type' ),
-		match_url: __( 'Match URL' ),
-		rule_order: __( 'Order' ),
-		match_headers: __( 'Request headers' ),
-		match_cookie: __( 'Cookies' ),
-		match_params: __( 'Request parameters' ),
-		match_capabilities: __( 'Capabilities' ),
-		match_ip: __( 'Visitor IP' ),
-		match_roles: __( 'Roles' ),
-		match_browser: __( 'Browser' ),
-		is_logged: __( 'Is logged in' ),
-		add_http_headers: __( 'Custom HTTP Headers' ),
-		add_start_headers: __( 'After <head>' ),
-		add_end_headers: __( 'Before </head>' ),
-		add_start_body: __( 'After <body>`' ),
-		add_end_body: __( 'Before `</body>`' ),
-	};
-
-	const rowEditorCells = {
-		name: <InputField liveUpdate autoFocus type="text" defaultValue="" label={ header.name } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, name: val } ) } />,
-
-		rule_order: <InputField liveUpdate type="number" defaultValue="10" label={ editRowCells.rule_order } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, rule_order: val } ) } />,
-
-		is_active: <Checkbox defaultValue={ true } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, is_active: val } ) }>{ header.is_active }</Checkbox>,
-
-		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, labels: val } ) } />,
-
-		match_type: <SingleSelectMenu defaultAccept autoClose items={ matchTypes } name="match_type" defaultValue="E"
-			description={ __( 'Choose when the rule should be applied' ) }
-			section="Match Pages"
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_type: val } ) }>{ editRowCells.match_type }</SingleSelectMenu>,
-
-		match_url: <InputField type="url" liveUpdate defaultValue="" label={ editRowCells.match_url } hidden={ rowToEdit?.match_type === 'A' }
-			description={ __( 'Match this value with the browser URL according to the selected rule type' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_url: val } ) } />,
-
-		match_headers: <InputField liveUpdate defaultValue="" label={ editRowCells.match_headers }
-			description={ __( 'Apply only for requests with specified HTTP headers sent from the browser. List the headers to be checked, separated by commas. For instance: HEADER-NAME, HEADER-NAME=value' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_headers: val } ) } />,
-
-		match_cookie: <InputField liveUpdate defaultValue="" label={ editRowCells.match_cookie }
-			description={ __( 'Apply only for requests with specified cookie sent from the browser. List the cookies to be checked, separated by commas. For instance: COOKIE_NAME, COOKIE_NAME=value' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_cookie: val } ) } />,
-
-		match_params: <InputField liveUpdate defaultValue="" label={ editRowCells.match_params }
-			description={ __( 'Apply only for requests with specified GET or POST parameter. List the parameters to be checked, separated by commas. For instance: query-param, query-param=value' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_params: val } ) } />,
-
-		match_capabilities: <InputField liveUpdate defaultValue="" label={ editRowCells.match_capabilities }
-			description={ __( 'Apply only for requests from users with certain capabilities' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_capabilities: val } ) } />,
-
-		match_ip: <InputField liveUpdate defaultValue="" label={ editRowCells.match_ip }
-			description={ __( 'Apply only for visitors from certain IP addresses or subnets. Provide a comma-separated list of IP addresses or subnets. For instance: 172.120.0.*, 192.168.0.0/24' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_ip: val } ) } />,
-
-		match_roles: <InputField liveUpdate defaultValue="" label={ editRowCells.match_roles }
-			description={ __( 'Apply only for requests from users with particular roles' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_roles: val } ) } />,
-
-		match_browser: <InputField liveUpdate defaultValue="" label={ editRowCells.match_browser }
-			description={ __( 'Apply for visitors using specific browsers. Input browser names or any string from User-Agent, separated by commas' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_browser: val } ) } />,
-
-		is_logged: <SingleSelectMenu autoClose items={ logginTypes } name="is_logged" defaultValue="A"
-			description={ __( 'Apply only to users with a specific login status' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, is_logged: val } ) }>{ editRowCells.is_logged }</SingleSelectMenu>,
-
-		add_http_headers: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_http_headers }
-			description={ __( 'Add custom HTTP headers transmitted from the server to the browser. Use new lines to separate headers. For instance: X-URLSLAB-HEADER=value' ) }
-			section="Injected Code"
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, add_http_headers: val } ) } />,
-
-		add_start_headers: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_start_headers }
-			description={ __( 'Custom HTML code inserted immediately after the opening `<head>` tag, applicable to all pages' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, add_start_headers: val } ) } />,
-
-		add_end_headers: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_end_headers }
-			description={ __( 'Custom HTML code inserted immediately before the closing `</head>` tag, applicable to all pages' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, add_end_headers: val } ) } />,
-
-		add_start_body: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_start_body }
-			description={ __( 'Custom HTML code inserted immediately after the opening `<body>` tag, applicable to all pages' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, add_start_body: val } ) } />,
-
-		add_end_body: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_end_body }
-			description={ __( 'Custom HTML code inserted immediately before the closing `</body>` tag, applicable to all pages' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, add_end_body: val } ) } />,
-	};
-
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId, 'dest_url_id' ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
 				tables: {
 					...useTableStore.getState().tables,
 					[ slug ]: {
-						data,
 						title,
 						paginationId,
 						slug,
@@ -178,16 +95,21 @@ export default function CustomHtmlTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'nolimit checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -225,7 +147,7 @@ export default function CustomHtmlTable( { slug } ) {
 			header: () => null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, selectRows, slug, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -248,6 +170,95 @@ export default function CustomHtmlTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager slug={ slug } />
 		</>
 	);
 }
+
+const TableEditorManager = memo( ( { slug } ) => {
+	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+
+	const rowEditorCells = useMemo( () => ( {
+		name: <InputField liveUpdate autoFocus type="text" defaultValue="" label={ header.name } onChange={ ( val ) => setRowToEdit( { name: val } ) } />,
+
+		rule_order: <InputField liveUpdate type="number" defaultValue="10" label={ editRowCells.rule_order } onChange={ ( val ) => setRowToEdit( { rule_order: val } ) } />,
+
+		is_active: <Checkbox defaultValue={ true } onChange={ ( val ) => setRowToEdit( { is_active: val } ) }>{ header.is_active }</Checkbox>,
+
+		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { labels: val } ) } />,
+
+		match_type: <SingleSelectMenu defaultAccept autoClose items={ matchTypes } name="match_type" defaultValue="E"
+			description={ __( 'Choose when the rule should be applied' ) }
+			section="Match Pages"
+			onChange={ ( val ) => setRowToEdit( { match_type: val } ) }>{ editRowCells.match_type }</SingleSelectMenu>,
+
+		match_url: <InputField type="url" liveUpdate defaultValue="" label={ editRowCells.match_url } hidden={ rowToEdit?.match_type === 'A' }
+			description={ __( 'Match this value with the browser URL according to the selected rule type' ) }
+			onChange={ ( val ) => setRowToEdit( { match_url: val } ) } />,
+
+		match_headers: <InputField liveUpdate defaultValue="" label={ editRowCells.match_headers }
+			description={ __( 'Apply only for requests with specified HTTP headers sent from the browser. List the headers to be checked, separated by commas. For instance: HEADER-NAME, HEADER-NAME=value' ) }
+			onChange={ ( val ) => setRowToEdit( { match_headers: val } ) } />,
+
+		match_cookie: <InputField liveUpdate defaultValue="" label={ editRowCells.match_cookie }
+			description={ __( 'Apply only for requests with specified cookie sent from the browser. List the cookies to be checked, separated by commas. For instance: COOKIE_NAME, COOKIE_NAME=value' ) }
+			onChange={ ( val ) => setRowToEdit( { match_cookie: val } ) } />,
+
+		match_params: <InputField liveUpdate defaultValue="" label={ editRowCells.match_params }
+			description={ __( 'Apply only for requests with specified GET or POST parameter. List the parameters to be checked, separated by commas. For instance: query-param, query-param=value' ) }
+			onChange={ ( val ) => setRowToEdit( { match_params: val } ) } />,
+
+		match_capabilities: <InputField liveUpdate defaultValue="" label={ editRowCells.match_capabilities }
+			description={ __( 'Apply only for requests from users with certain capabilities' ) }
+			onChange={ ( val ) => setRowToEdit( { match_capabilities: val } ) } />,
+
+		match_ip: <InputField liveUpdate defaultValue="" label={ editRowCells.match_ip }
+			description={ __( 'Apply only for visitors from certain IP addresses or subnets. Provide a comma-separated list of IP addresses or subnets. For instance: 172.120.0.*, 192.168.0.0/24' ) }
+			onChange={ ( val ) => setRowToEdit( { match_ip: val } ) } />,
+
+		match_roles: <InputField liveUpdate defaultValue="" label={ editRowCells.match_roles }
+			description={ __( 'Apply only for requests from users with particular roles' ) }
+			onChange={ ( val ) => setRowToEdit( { match_roles: val } ) } />,
+
+		match_browser: <InputField liveUpdate defaultValue="" label={ editRowCells.match_browser }
+			description={ __( 'Apply for visitors using specific browsers. Input browser names or any string from User-Agent, separated by commas' ) }
+			onChange={ ( val ) => setRowToEdit( { match_browser: val } ) } />,
+
+		is_logged: <SingleSelectMenu autoClose items={ logginTypes } name="is_logged" defaultValue="A"
+			description={ __( 'Apply only to users with a specific login status' ) }
+			onChange={ ( val ) => setRowToEdit( { is_logged: val } ) }>{ editRowCells.is_logged }</SingleSelectMenu>,
+
+		add_http_headers: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_http_headers }
+			description={ __( 'Add custom HTTP headers transmitted from the server to the browser. Use new lines to separate headers. For instance: X-URLSLAB-HEADER=value' ) }
+			section="Injected Code"
+			onChange={ ( val ) => setRowToEdit( { add_http_headers: val } ) } />,
+
+		add_start_headers: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_start_headers }
+			description={ __( 'Custom HTML code inserted immediately after the opening `<head>` tag, applicable to all pages' ) }
+			onChange={ ( val ) => setRowToEdit( { add_start_headers: val } ) } />,
+
+		add_end_headers: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_end_headers }
+			description={ __( 'Custom HTML code inserted immediately before the closing `</head>` tag, applicable to all pages' ) }
+			onChange={ ( val ) => setRowToEdit( { add_end_headers: val } ) } />,
+
+		add_start_body: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_start_body }
+			description={ __( 'Custom HTML code inserted immediately after the opening `<body>` tag, applicable to all pages' ) }
+			onChange={ ( val ) => setRowToEdit( { add_start_body: val } ) } />,
+
+		add_end_body: <TextArea rows="5" liveUpdate defaultValue="" label={ editRowCells.add_end_body }
+			description={ __( 'Custom HTML code inserted immediately before the closing `</body>` tag, applicable to all pages' ) }
+			onChange={ ( val ) => setRowToEdit( { add_end_body: val } ) } />,
+
+	} ), [ rowToEdit?.match_type, setRowToEdit, slug ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+				deleteCSVCols: [ paginationId, 'dest_url_id' ],
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/FaqUrlsTable.jsx
+++ b/admin/src/tables/FaqUrlsTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch,
@@ -19,14 +19,20 @@ import useTableStore from '../hooks/useTableStore';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const title = __( 'Add New FAQ to URL' );
+const paginationId = 'faq_id';
+const optionalSelector = 'url_id';
+
+const defaultSorting = [ { key: 'url_name', dir: 'ASC', op: '>' }, { key: 'sorting', dir: 'ASC', op: '>' } ];
+
+const header = {
+	url_name: __( 'URL' ),
+	faq_id: __( 'Question ID' ),
+	question: __( 'Question' ),
+	sorting: __( 'Position' ),
+};
+
 export default function FaqUrlsTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add New FAQ to URL' );
-	const paginationId = 'faq_id';
-	const optionalSelector = 'url_id';
-
-	const defaultSorting = [ { key: 'url_name', dir: 'ASC', op: '>' }, { key: 'sorting', dir: 'ASC', op: '>' } ];
-
 	const {
 		columnHelper,
 		data,
@@ -39,31 +45,7 @@ export default function FaqUrlsTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-
-	const header = {
-		url_name: __( 'URL' ),
-		faq_id: __( 'Question ID' ),
-		question: __( 'Question' ),
-		sorting: __( 'Position' ),
-	};
-
-	const rowEditorCells = {
-		url_name: <InputField liveUpdate type="url" defaultValue="" label={ header.url_name } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, url_name: val } ) } required />,
-		faq_id: <InputField liveUpdate defaultValue="" type="number" label={ header.faq_id } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, faq_id: val } ) } required />,
-		sorting: <InputField liveUpdate type="number" defaultValue="10" label={ header.sorting } min="0" max="100"
-			description={ __( 'Position of the FAQ in the list (Number 0 - 100).' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, sorting: val } ) } />,
-	};
-
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ 'url_id' ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -83,16 +65,21 @@ export default function FaqUrlsTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'nolimit checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -135,7 +122,7 @@ export default function FaqUrlsTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, selectRows, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -159,6 +146,29 @@ export default function FaqUrlsTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager />
 		</>
 	);
 }
+
+const TableEditorManager = memo( () => {
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+
+	const rowEditorCells = useMemo( () => ( {
+		url_name: <InputField liveUpdate type="url" defaultValue="" label={ header.url_name } onChange={ ( val ) => setRowToEdit( { url_name: val } ) } required />,
+		faq_id: <InputField liveUpdate defaultValue="" type="number" label={ header.faq_id } onChange={ ( val ) => setRowToEdit( { faq_id: val } ) } required />,
+		sorting: <InputField liveUpdate type="number" defaultValue="10" label={ header.sorting } min="0" max="100"
+			description={ __( 'Position of the FAQ in the list (Number 0 - 100).' ) }
+			onChange={ ( val ) => setRowToEdit( { sorting: val } ) } />,
+	} ), [ setRowToEdit ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+				deleteCSVCols: [ 'url_id' ],
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/FaqsTable.jsx
+++ b/admin/src/tables/FaqsTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import {
 	Checkbox,
@@ -31,37 +31,30 @@ import SingleSelectMenu from '../elements/SingleSelectMenu';
 import { getTooltipUrlsList } from '../lib/elementsHelpers';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const title = __( 'Add New FAQ' );
+const paginationId = 'faq_id';
+
+const statusTypes = {
+	A: __( 'Active' ),
+	N: __( 'New - answered' ),
+	E: __( 'New - missing answer' ),
+	W: __( 'Awaiting approval' ),
+	P: __( 'Processing answer' ),
+	D: __( 'Disabled' ),
+};
+
+const header = {
+	faq_id: __( 'ID' ),
+	question: __( 'Question' ),
+	language: __( 'Language' ),
+	status: __( 'Status' ),
+	urls_count: __( 'Assigned URLs' ),
+	updated: __( 'Updated' ),
+	labels: __( 'Tags' ),
+	urls: __( 'Assigned URLs' ),
+};
+
 export default function FaqsTable( { slug } ) {
-	const { __ } = useI18n();
-
-	const title = __( 'Add New FAQ' );
-	const paginationId = 'faq_id';
-
-	const ActionButton = ( { cell, onClick } ) => {
-		const { status } = cell?.row?.original;
-
-		return (
-			<div className="flex flex-align-center flex-justify-end">
-				{
-					( status === 'D' ) &&
-					<Tooltip title={ __( 'Activate' ) }>
-						<IconButton size="xs" color="success" onClick={ () => onClick( 'A' ) }>
-							<SvgIcon name="activate" />
-						</IconButton>
-					</Tooltip>
-				}
-				{
-					( status === 'A' ) &&
-					<Tooltip title={ __( 'Disable' ) }>
-						<IconButton size="xs" color="danger" onClick={ () => onClick( 'D' ) }>
-							<SvgIcon name="disable" />
-						</IconButton>
-					</Tooltip>
-				}
-			</div>
-		);
-	};
-
 	const {
 		columnHelper,
 		data,
@@ -74,76 +67,32 @@ export default function FaqsTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const { activatePanel, setRowToEdit, rowToEdit } = useTablePanels();
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
+		const { status: statusType } = cell?.row?.original;
 
-	const statusTypes = {
-		A: __( 'Active' ),
-		N: __( 'New - answered' ),
-		E: __( 'New - missing answer' ),
-		W: __( 'Awaiting approval' ),
-		P: __( 'Processing answer' ),
-		D: __( 'Disabled' ),
-	};
-
-	const header = {
-		faq_id: __( 'ID' ),
-		question: __( 'Question' ),
-		language: __( 'Language' ),
-		status: __( 'Status' ),
-		urls_count: __( 'Assigned URLs' ),
-		updated: __( 'Updated' ),
-		labels: __( 'Tags' ),
-		urls: __( 'Assigned URLs' ),
-	};
-
-	// Saving all variables into state managers
-	const rowEditorCells = {
-		question: <InputField liveUpdate defaultValue={ rowToEdit.question } label={ header.question }
-			description={ __( 'Maximum of 500 characters' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, question: val } ) } required />,
-
-		answer: <Editor
-			description={ ( __( 'Answer to the question' ) ) }
-			defaultValue="" label={ __( 'Answer' ) } onChange={ ( val ) => {
-				setRowToEdit( { ...rowToEdit, answer: val } );
-			} } />,
-
-		language: <LangMenu autoClose defaultValue="all"
-			description={ __( 'Select language' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, language: val } ) }>{ header.language }</LangMenu>,
-
-		generate: <Button
-			className="generatorBtn"
-			disabled={ ! rowToEdit.question }
-			onClick={ () => activatePanel( 'answerGeneratorPanel' ) }
-			startDecorator={ <IconStars /> }
-		>
-			{ __( 'Generate Answer' ) }
-		</Button>,
-
-		status: <SingleSelectMenu
-			defaultAccept
-			defaultValue="E"
-			onChange={ ( value ) => setRowToEdit( { ...rowToEdit, status: value } ) }
-			name="status"
-			items={ statusTypes }
-			autoClose
-			description={ __( 'The Status of the FAQ' ) }
-			tooltipLabel={ { label: __( 'FAQ Status' ), tooltip: __( 'FAQ Status' ), noWrapText: true } }
-		>{ __( 'FAQ Status' ) }</SingleSelectMenu>,
-
-		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, labels: val } ) } />,
-		urls: <TextArea rows="5" liveUpdate defaultValue="" label={ header.urls }
-			description={ __( 'New line or comma separated list of URLs, where is FAQ assigned. We recommend to use one URL only, otherwise google can understand it as duplicate content if you display same FAQ entry on multiple pages' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, urls: val } ) } />,
-	};
+		return (
+			<div className="flex flex-align-center flex-justify-end">
+				{
+					( statusType === 'D' ) &&
+					<Tooltip title={ __( 'Activate' ) }>
+						<IconButton size="xs" color="success" onClick={ () => onClick( 'A' ) }>
+							<SvgIcon name="activate" />
+						</IconButton>
+					</Tooltip>
+				}
+				{
+					( statusType === 'A' ) &&
+					<Tooltip title={ __( 'Disable' ) }>
+						<IconButton size="xs" color="danger" onClick={ () => onClick( 'D' ) }>
+							<SvgIcon name="disable" />
+						</IconButton>
+					</Tooltip>
+				}
+			</div>
+		);
+	}, [] );
 
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -164,12 +113,18 @@ export default function FaqsTable( { slug } ) {
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'nolimit checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -242,7 +197,7 @@ export default function FaqsTable( { slug } ) {
 			header: () => null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, selectRows, slug, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -266,6 +221,63 @@ export default function FaqsTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager slug={ slug } />
 		</>
 	);
 }
+
+const TableEditorManager = memo( ( { slug } ) => {
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+
+	const rowEditorCells = useMemo( () => ( {
+		question: <InputField liveUpdate defaultValue={ rowToEdit.question } label={ header.question }
+			description={ __( 'Maximum of 500 characters' ) }
+			onChange={ ( val ) => setRowToEdit( { question: val } ) } required />,
+
+		answer: <Editor
+			description={ ( __( 'Answer to the question' ) ) }
+			defaultValue="" label={ __( 'Answer' ) } onChange={ ( val ) => {
+				setRowToEdit( { answer: val } );
+			} } />,
+
+		language: <LangMenu autoClose defaultValue="all"
+			description={ __( 'Select language' ) }
+			onChange={ ( val ) => setRowToEdit( { language: val } ) }>{ header.language }</LangMenu>,
+
+		generate: <Button
+			className="generatorBtn"
+			disabled={ ! rowToEdit.question }
+			onClick={ () => activatePanel( 'answerGeneratorPanel' ) }
+			startDecorator={ <IconStars /> }
+		>
+			{ __( 'Generate Answer' ) }
+		</Button>,
+
+		status: <SingleSelectMenu
+			defaultAccept
+			defaultValue="E"
+			onChange={ ( value ) => setRowToEdit( { status: value } ) }
+			name="status"
+			items={ statusTypes }
+			autoClose
+			description={ __( 'The Status of the FAQ' ) }
+			tooltipLabel={ { label: __( 'FAQ Status' ), tooltip: __( 'FAQ Status' ), noWrapText: true } }
+		>{ __( 'FAQ Status' ) }</SingleSelectMenu>,
+
+		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { labels: val } ) } />,
+		urls: <TextArea rows="5" liveUpdate defaultValue="" label={ header.urls }
+			description={ __( 'New line or comma separated list of URLs, where is FAQ assigned. We recommend to use one URL only, otherwise google can understand it as duplicate content if you display same FAQ entry on multiple pages' ) }
+			onChange={ ( val ) => setRowToEdit( { urls: val } ) } />,
+	} ), [ activatePanel, rowToEdit.question, setRowToEdit, slug ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/GeneratorProcessesTable.jsx
+++ b/admin/src/tables/GeneratorProcessesTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import {
 	Checkbox,
@@ -18,10 +18,31 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTableStore from '../hooks/useTableStore';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function GeneratorProcessesTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'task_id';
+const paginationId = 'task_id';
 
+const generatorType = {
+	S: __( 'Shortcode' ),
+	P: __( 'Post creation' ),
+	F: __( 'FAQ Answer Generation' ),
+};
+
+const generatorStatus = {
+	N: __( 'New' ),
+	P: __( 'Processing' ),
+	A: __( 'Done' ),
+	D: __( 'Failed' ),
+};
+
+const header = {
+	task_id: __( 'ID' ),
+	generator_type: __( 'Generator type' ),
+	task_status: __( 'Status' ),
+	task_data: __( 'Task data' ),
+	result_log: __( 'Result' ),
+	updated: __( 'Last change' ),
+};
+
+export default function GeneratorProcessesTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -33,28 +54,6 @@ export default function GeneratorProcessesTable( { slug } ) {
 	} = useInfiniteFetch( { slug } );
 
 	const { isSelected, selectRows, deleteRow } = useChangeRow( );
-
-	const generatorType = {
-		S: __( 'Shortcode' ),
-		P: __( 'Post creation' ),
-		F: __( 'FAQ Answer Generation' ),
-	};
-
-	const generatorStatus = {
-		N: __( 'New' ),
-		P: __( 'Processing' ),
-		A: __( 'Done' ),
-		D: __( 'Failed' ),
-	};
-
-	const header = {
-		task_id: __( 'ID' ),
-		generator_type: __( 'Generator type' ),
-		task_status: __( 'Status' ),
-		task_data: __( 'Task data' ),
-		result_log: __( 'Result' ),
-		updated: __( 'Last change' ),
-	};
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -73,16 +72,21 @@ export default function GeneratorProcessesTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'nolimit checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -135,7 +139,7 @@ export default function GeneratorProcessesTable( { slug } ) {
 			header: () => null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, selectRows ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/GeneratorPromptTemplateTable.jsx
+++ b/admin/src/tables/GeneratorPromptTemplateTable.jsx
@@ -185,21 +185,31 @@ const TableEditorManager = memo( () => {
 	} ), [ aiModels, aiModelsSuccess, rowToEdit, setRowToEdit ] );
 
 	useEffect( () => {
+		if ( aiModelsSuccess ) {
+			useTablePanels.setState( () => (
+				{
+					...useTablePanels.getState(),
+					rowEditorCells: {
+						...rowEditorCells,
+						model_name: {
+							...rowEditorCells.model_name,
+							props: {
+								...rowEditorCells.model_name.props,
+								items: aiModels,
+							},
+						},
+					},
+				}
+			) );
+		}
+	}, [ aiModels, aiModelsSuccess, rowEditorCells ] );
+
+	useEffect( () => {
 		useTablePanels.setState( () => (
 			{
 				...useTablePanels.getState(),
-				rowEditorCells: {
-					...rowEditorCells,
-					model_name: {
-						...rowEditorCells.model_name,
-						props: {
-							...rowEditorCells.model_name.props,
-							items: aiModels,
-						},
-					},
-				},
-				deleteCSVCols: [ 'url_id' ],
+				deleteCSVCols: [ paginationId ],
 			}
 		) );
-	}, [ aiModels, rowEditorCells ] );
+	}, [] );
 } );

--- a/admin/src/tables/GeneratorPromptTemplateTable.jsx
+++ b/admin/src/tables/GeneratorPromptTemplateTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import {
 	useInfiniteFetch,
@@ -22,13 +22,23 @@ import useAIModelsQuery from '../queries/useAIModelsQuery';
 import TextArea from '../elements/Textarea';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const title = __( 'Add New Prompt Template' );
+const paginationId = 'template_id';
+
+const templateTypes = {
+	B: __( 'Blog generation' ),
+	A: __( 'Question answering' ),
+};
+
+const header = {
+	template_name: __( 'Name' ),
+	prompt_type: __( 'Prompt type' ),
+	prompt_template: __( 'Prompt template' ),
+	model_name: __( 'Model' ),
+	updated: __( 'Updated' ),
+};
+
 export default function GeneratorPromptTemplateTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add New Prompt Template' );
-	const paginationId = 'template_id';
-
-	const { data: aiModels, isSuccess: aiModelsSuccess } = useAIModelsQuery();
-
 	const {
 		columnHelper,
 		data,
@@ -39,47 +49,11 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 		ref,
 	} = useInfiniteFetch( { slug } );
 
+	const { data: aiModels, isSuccess: aiModelsSuccess } = useAIModelsQuery();
+
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-
-	const templateTypes = {
-		B: __( 'Blog generation' ),
-		A: __( 'Question answering' ),
-	};
-
-	const header = {
-		template_name: __( 'Name' ),
-		prompt_type: __( 'Prompt type' ),
-		prompt_template: __( 'Prompt template' ),
-		model_name: __( 'Model' ),
-		updated: __( 'Updated' ),
-	};
-
-	const rowEditorCells = {
-		template_name: <InputField defaultValue="" liveUpdate label={ header.template_name }
-			description={ __( 'Prompt name for simple identification' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, template_name: val } ) } required />,
-
-		prompt_template: <TextArea liveUpdate allowResize rows={ 15 }
-			description={ ( __( 'Prompt template used to generate text' ) ) }
-			defaultValue="" label={ header.prompt_template } onChange={ ( val ) => {
-				setRowToEdit( { ...rowToEdit, prompt_template: val } );
-			} } />,
-
-		model_name: <SingleSelectMenu autoClose defaultAccept description={ __( 'AI model used for the prompt' ) } items={ aiModelsSuccess ? aiModels : {} } defaultValue={ aiModelsSuccess ? Object.keys( aiModels )[ 0 ] : '' } name="model" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, model_name: val } ) }>{ header.model_name }</SingleSelectMenu>,
-
-		prompt_type: <SingleSelectMenu autoClose defaultAccept description={ __( 'Task type used for the prompt' ) } items={ templateTypes } defaultValue="B" name="prompt_type" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, prompt_type: val } ) }>{ header.prompt_type }</SingleSelectMenu>,
-	};
-
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ 'url_id' ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -97,21 +71,21 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells: { ...rowEditorCells, model_name: { ...rowEditorCells.model_name, props: { ...rowEditorCells.model_name.props, items: aiModels } } },
-			}
-		) );
-	}, [ data, slug, aiModels ] );
+	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'nolimit checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -159,7 +133,7 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 			header: () => null,
 			size: 0,
 		} ),
-	];
+	], [ aiModels, aiModelsSuccess, columnHelper, deleteRow, isSelected, selectRows, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -183,6 +157,49 @@ export default function GeneratorPromptTemplateTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager />
 		</>
 	);
 }
+
+const TableEditorManager = memo( () => {
+	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const { data: aiModels, isSuccess: aiModelsSuccess } = useAIModelsQuery();
+
+	const rowEditorCells = useMemo( () => ( {
+		template_name: <InputField defaultValue="" liveUpdate label={ header.template_name }
+			description={ __( 'Prompt name for simple identification' ) }
+			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, template_name: val } ) } required />,
+
+		prompt_template: <TextArea liveUpdate allowResize rows={ 15 }
+			description={ ( __( 'Prompt template used to generate text' ) ) }
+			defaultValue="" label={ header.prompt_template } onChange={ ( val ) => {
+				setRowToEdit( { ...rowToEdit, prompt_template: val } );
+			} } />,
+
+		model_name: <SingleSelectMenu autoClose defaultAccept description={ __( 'AI model used for the prompt' ) } items={ aiModelsSuccess ? aiModels : {} } defaultValue={ aiModelsSuccess ? Object.keys( aiModels )[ 0 ] : '' } name="model" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, model_name: val } ) }>{ header.model_name }</SingleSelectMenu>,
+
+		prompt_type: <SingleSelectMenu autoClose defaultAccept description={ __( 'Task type used for the prompt' ) } items={ templateTypes } defaultValue="B" name="prompt_type" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, prompt_type: val } ) }>{ header.prompt_type }</SingleSelectMenu>,
+
+	} ), [ aiModels, aiModelsSuccess, rowToEdit, setRowToEdit ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells: {
+					...rowEditorCells,
+					model_name: {
+						...rowEditorCells.model_name,
+						props: {
+							...rowEditorCells.model_name.props,
+							items: aiModels,
+						},
+					},
+				},
+				deleteCSVCols: [ 'url_id' ],
+			}
+		) );
+	}, [ aiModels, rowEditorCells ] );
+} );

--- a/admin/src/tables/GeneratorShortcodeTable.jsx
+++ b/admin/src/tables/GeneratorShortcodeTable.jsx
@@ -314,27 +314,37 @@ const TableEditorManager = memo( () => {
 			setRowToEdit( { template: val } );
 		} } required />,
 
-		model: <SingleSelectMenu defaultAccept autoClose items={ aiModelsSuccess ? aiModels : {} } name="model" defaultValue={ ( 'gpt-3.5-turbo' ) } onChange={ ( val ) => setRowToEdit( { model: val } ) }>{ header.model }</SingleSelectMenu>,
+		model: <SingleSelectMenu defaultAccept autoClose items={ aiModelsSuccess ? aiModels : {} } name="model" defaultValue="gpt-3.5-turbo" onChange={ ( val ) => setRowToEdit( { model: val } ) }>{ header.model }</SingleSelectMenu>,
 
 	} ), [ aiModels, aiModelsSuccess, rowToEdit?.shortcode_type, setRowToEdit ] );
+
+	useEffect( () => {
+		if ( aiModelsSuccess ) {
+			useTablePanels.setState( () => (
+				{
+					...useTablePanels.getState(),
+					rowEditorCells: {
+						...rowEditorCells,
+						model: {
+							...rowEditorCells.model,
+							props: {
+								...rowEditorCells.model.props,
+								items: aiModels,
+							},
+						},
+					},
+				}
+			) );
+		}
+	}, [ aiModels, aiModelsSuccess, rowEditorCells ] );
 
 	useEffect( () => {
 		useTablePanels.setState( () => (
 			{
 				...useTablePanels.getState(),
-				rowEditorCells: {
-					...rowEditorCells,
-					model: {
-						...rowEditorCells.model,
-						props: {
-							...rowEditorCells.model.props,
-							items: aiModels,
-						},
-					},
-				},
 				deleteCSVCols: [ paginationId ],
 			}
 		) );
-	}, [ aiModels, rowEditorCells ] );
+	}, [] );
 } );
 

--- a/admin/src/tables/GeneratorShortcodeTable.jsx
+++ b/admin/src/tables/GeneratorShortcodeTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -32,37 +32,42 @@ import useAIModelsQuery from '../queries/useAIModelsQuery';
 import copyToClipBoard from '../lib/copyToClipBoard';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const title = __( 'Add New Shortcode' );
+const paginationId = 'shortcode_id';
+const supported_variables_description = __( 'Supported variables: {{page_title}}, {{page_url}}, {{domain}}, {{language_code}}, {{language}}. If the `videoid` attribute is enabled, the following variables can be used: {{video_captions}}, {{video_captions_text}}, {{video_title}}, {{video_description}}, {{video_published_at}}, {{video_duration}}, {{video_channel_title}}, {{video_tags}}. Custom attributes can also be incorporated via shortcode in the form {{your_custom_attribute_name}}' );
+
+const statusTypes = {
+	A: __( 'Active' ),
+	D: __( 'Disabled' ),
+};
+const modelTypes = {
+	'gpt-3.5-turbo': __( 'OpenAI GPT 3.5 Turbo' ),
+	'gpt-4': __( 'OpenAI GPT 4' ),
+	'text-davinci-003': __( 'OpenAI GPT Davinci 003' ),
+};
+const shortcodeTypeTypes = {
+	S: __( 'Semantic search' ),
+	V: __( 'Video context' ),
+};
+
+const header = {
+	shortcode_id: __( 'ID' ),
+	shortcode_name: __( 'Name' ),
+	shortcode_type: __( 'Type' ),
+	prompt: __( 'Prompt' ),
+	semantic_context: __( 'Semantic context' ),
+	url_filter: __( 'URL filter' ),
+	default_value: __( 'Default value' ),
+	template: __( 'HTML template' ),
+	model: __( 'Model' ),
+	status: __( 'Status' ),
+	date_changed: __( 'Last change' ),
+	usage_count: __( 'Usage' ),
+	shortcode: __( 'Shortcode' ),
+};
+
 export default function GeneratorShortcodeTable( { slug } ) {
-	const { __ } = useI18n();
-	const { data: aiModels, isSuccess: aiModelsSuccess } = useAIModelsQuery();
-	const title = __( 'Add New Shortcode' );
-	const paginationId = 'shortcode_id';
 	const queryClient = useQueryClient();
-
-	const ActionButton = ( { cell, onClick } ) => {
-		const { status } = cell?.row?.original;
-
-		return (
-			<div className="flex flex-align-center flex-justify-end">
-				{
-					( status !== 'A' ) &&
-					<Tooltip title={ __( 'Activate' ) }>
-						<IconButton size="xs" color="success" onClick={ () => onClick( 'A' ) }>
-							<SvgIcon name="activate" />
-						</IconButton>
-					</Tooltip>
-				}
-				{
-					( status !== 'D' ) &&
-					<Tooltip title={ __( 'Disable' ) }>
-						<IconButton size="xs" color="danger" onClick={ () => onClick( 'D' ) }>
-							<SvgIcon name="disable" />
-						</IconButton>
-					</Tooltip>
-				}
-			</div>
-		);
-	};
 
 	const {
 		columnHelper,
@@ -76,71 +81,32 @@ export default function GeneratorShortcodeTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
+		const { status: statusType } = cell?.row?.original;
 
-	const statusTypes = {
-		A: __( 'Active' ),
-		D: __( 'Disabled' ),
-	};
-	const modelTypes = {
-		'gpt-3.5-turbo': __( 'OpenAI GPT 3.5 Turbo' ),
-		'gpt-4': __( 'OpenAI GPT 4' ),
-		'text-davinci-003': __( 'OpenAI GPT Davinci 003' ),
-	};
-	const shortcodeTypeTypes = {
-		S: __( 'Semantic search' ),
-		V: __( 'Video context' ),
-	};
-
-	const header = {
-		shortcode_id: __( 'ID' ),
-		shortcode_name: __( 'Name' ),
-		shortcode_type: __( 'Type' ),
-		prompt: __( 'Prompt' ),
-		semantic_context: __( 'Semantic context' ),
-		url_filter: __( 'URL filter' ),
-		default_value: __( 'Default value' ),
-		template: __( 'HTML template' ),
-		model: __( 'Model' ),
-		status: __( 'Status' ),
-		date_changed: __( 'Last change' ),
-		usage_count: __( 'Usage' ),
-		shortcode: __( 'Shortcode' ),
-	};
-
-	const supported_variables_description = __( 'Supported variables: {{page_title}}, {{page_url}}, {{domain}}, {{language_code}}, {{language}}. If the `videoid` attribute is enabled, the following variables can be used: {{video_captions}}, {{video_captions_text}}, {{video_title}}, {{video_description}}, {{video_published_at}}, {{video_duration}}, {{video_channel_title}}, {{video_tags}}. Custom attributes can also be incorporated via shortcode in the form {{your_custom_attribute_name}}' );
-
-	const rowEditorCells = {
-		shortcode_name: <InputField liveUpdate defaultValue="" description={ __( 'Shortcode name for simple identification' ) } label={ header.shortcode_name } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, shortcode_name: val } ) } required />,
-
-		shortcode_type: <SingleSelectMenu autoClose defaultAccept description={ __( 'For video context types, the semantic search query should include a YouTube video ID or YouTube video URL' ) }
-			items={ shortcodeTypeTypes } name="shortcode_type" defaultValue="S" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, shortcode_type: val } ) }>{ header.shortcode_type }</SingleSelectMenu>,
-
-		prompt: <TextArea rows="5" description={ ( supported_variables_description ) }
-			liveUpdate defaultValue="" label={ header.prompt } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, prompt: val } ) } required />,
-
-		semantic_context: <InputField liveUpdate description={ ( supported_variables_description + ' ' + __( 'For video context types, the semantic context must include the YouTube video ID: {{videoid}}' ) ) }
-			defaultValue="" label={ header.semantic_context } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, semantic_context: val } ) } hidden={ rowToEdit?.shortcode_type === 'V' } />,
-
-		url_filter: <InputField liveUpdate defaultValue="" description={ __( 'Suggested variables: {{page_url}} for generating data from the current URL. {{domain}} for generating data from any semantically relevant page on your domain. Use a fixed URL for generating data from a specific URL. {{custom_url_attribute_name}} if a custom attribute is forwarded to the shortcode in the HTML template' ) } label={ header.url_filter } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, url_filter: val } ) } hidden={ rowToEdit?.shortcode_type === 'V' } />,
-
-		default_value: <InputField liveUpdate description={ __( 'Enter the text to be shown in the shortcode prior to URLsLab generating text from your prompt. If no text is desired, leave blank' ) } defaultValue="" label={ header.default_value } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, default_value: val } ) } />,
-
-		template: <Editor description={ ( supported_variables_description + __( ' The generated text value can be retrieved in the template via the {{value}} variable. If the generator produced a JSON, you can access it using {{json_value.attribute_name}}' ) ) } defaultValue="" label={ header.template } onChange={ ( val ) => {
-			setRowToEdit( { ...rowToEdit, template: val } );
-		} } required />,
-
-		model: <SingleSelectMenu defaultAccept autoClose items={ aiModelsSuccess ? aiModels : {} } name="model" defaultValue={ ( 'gpt-3.5-turbo' ) } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, model: val } ) }>{ header.model }</SingleSelectMenu>,
-	};
+		return (
+			<div className="flex flex-align-center flex-justify-end">
+				{
+					( statusType !== 'A' ) &&
+					<Tooltip title={ __( 'Activate' ) }>
+						<IconButton size="xs" color="success" onClick={ () => onClick( 'A' ) }>
+							<SvgIcon name="activate" />
+						</IconButton>
+					</Tooltip>
+				}
+				{
+					( statusType !== 'D' ) &&
+					<Tooltip title={ __( 'Disable' ) }>
+						<IconButton size="xs" color="danger" onClick={ () => onClick( 'D' ) }>
+							<SvgIcon name="disable" />
+						</IconButton>
+					</Tooltip>
+				}
+			</div>
+		);
+	}, [] );
 
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -157,21 +123,21 @@ export default function GeneratorShortcodeTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells: { ...rowEditorCells, model: { ...rowEditorCells.model, props: { ...rowEditorCells.model.props, items: aiModels } } },
-			}
-		) );
-	}, [ data, slug, aiModels ] );
+	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -291,7 +257,7 @@ export default function GeneratorShortcodeTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, queryClient, selectRows, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -317,6 +283,58 @@ export default function GeneratorShortcodeTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager />
 		</>
 	);
 }
+
+const TableEditorManager = memo( () => {
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+
+	const { data: aiModels, isSuccess: aiModelsSuccess } = useAIModelsQuery();
+
+	const rowEditorCells = useMemo( () => ( {
+		shortcode_name: <InputField liveUpdate defaultValue="" description={ __( 'Shortcode name for simple identification' ) } label={ header.shortcode_name } onChange={ ( val ) => setRowToEdit( { shortcode_name: val } ) } required />,
+
+		shortcode_type: <SingleSelectMenu autoClose defaultAccept description={ __( 'For video context types, the semantic search query should include a YouTube video ID or YouTube video URL' ) }
+			items={ shortcodeTypeTypes } name="shortcode_type" defaultValue="S" onChange={ ( val ) => setRowToEdit( { shortcode_type: val } ) }>{ header.shortcode_type }</SingleSelectMenu>,
+
+		prompt: <TextArea rows="5" description={ ( supported_variables_description ) }
+			liveUpdate defaultValue="" label={ header.prompt } onChange={ ( val ) => setRowToEdit( { prompt: val } ) } required />,
+
+		semantic_context: <InputField liveUpdate description={ ( supported_variables_description + ' ' + __( 'For video context types, the semantic context must include the YouTube video ID: {{videoid}}' ) ) }
+			defaultValue="" label={ header.semantic_context } onChange={ ( val ) => setRowToEdit( { semantic_context: val } ) } hidden={ rowToEdit?.shortcode_type === 'V' } />,
+
+		url_filter: <InputField liveUpdate defaultValue="" description={ __( 'Suggested variables: {{page_url}} for generating data from the current URL. {{domain}} for generating data from any semantically relevant page on your domain. Use a fixed URL for generating data from a specific URL. {{custom_url_attribute_name}} if a custom attribute is forwarded to the shortcode in the HTML template' ) } label={ header.url_filter } onChange={ ( val ) => setRowToEdit( { url_filter: val } ) } hidden={ rowToEdit?.shortcode_type === 'V' } />,
+
+		default_value: <InputField liveUpdate description={ __( 'Enter the text to be shown in the shortcode prior to URLsLab generating text from your prompt. If no text is desired, leave blank' ) } defaultValue="" label={ header.default_value } onChange={ ( val ) => setRowToEdit( { default_value: val } ) } />,
+
+		template: <Editor description={ ( supported_variables_description + __( ' The generated text value can be retrieved in the template via the {{value}} variable. If the generator produced a JSON, you can access it using {{json_value.attribute_name}}' ) ) } defaultValue="" label={ header.template } onChange={ ( val ) => {
+			setRowToEdit( { template: val } );
+		} } required />,
+
+		model: <SingleSelectMenu defaultAccept autoClose items={ aiModelsSuccess ? aiModels : {} } name="model" defaultValue={ ( 'gpt-3.5-turbo' ) } onChange={ ( val ) => setRowToEdit( { model: val } ) }>{ header.model }</SingleSelectMenu>,
+
+	} ), [ aiModels, aiModelsSuccess, rowToEdit?.shortcode_type, setRowToEdit ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells: {
+					...rowEditorCells,
+					model: {
+						...rowEditorCells.model,
+						props: {
+							...rowEditorCells.model.props,
+							items: aiModels,
+						},
+					},
+				},
+				deleteCSVCols: [ paginationId ],
+			}
+		) );
+	}, [ aiModels, rowEditorCells ] );
+} );
+

--- a/admin/src/tables/JSCacheTable.jsx
+++ b/admin/src/tables/JSCacheTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch, ProgressBar, SortBy, Tooltip, Checkbox, Loader, Table, ModuleViewHeaderBottom, TooltipSortingFiltering, DateTimeFormat, IconButton, SvgIcon, RowActionButtons,
@@ -9,10 +9,23 @@ import useTableStore from '../hooks/useTableStore';
 import useChangeRow from '../hooks/useChangeRow';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function JSCacheTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'url_id';
+const paginationId = 'url_id';
 
+const statusTypes = {
+	N: __( 'New' ),
+	A: __( 'Available' ),
+	P: __( 'Processing' ),
+	D: __( 'Disabled' ),
+};
+
+const header = {
+	url: __( 'URL' ),
+	filesize: __( 'File size' ),
+	status: __( 'Status' ),
+	status_changed: __( 'Last change' ),
+};
+
+export default function JSCacheTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -25,7 +38,7 @@ export default function JSCacheTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const ActionButton = ( { cell, onClick } ) => {
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
 		const { status: jsStatus } = cell?.row?.original;
 
 		return (
@@ -36,21 +49,7 @@ export default function JSCacheTable( { slug } ) {
 				</IconButton>
 			</Tooltip>
 		);
-	};
-
-	const statusTypes = {
-		N: __( 'New' ),
-		A: __( 'Available' ),
-		P: __( 'Processing' ),
-		D: __( 'Disabled' ),
-	};
-
-	const header = {
-		url: __( 'URL' ),
-		filesize: __( 'File size' ),
-		status: __( 'Status' ),
-		status_changed: __( 'Last change' ),
-	};
+	}, [] );
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -68,16 +67,21 @@ export default function JSCacheTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -119,7 +123,7 @@ export default function JSCacheTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, selectRows, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/KeywordsTable.jsx
+++ b/admin/src/tables/KeywordsTable.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable indent */
-import { useCallback, useEffect, useMemo } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useCallback, useEffect, useMemo, memo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch, ProgressBar, TagsMenu, SortBy, SingleSelectMenu, LangMenu, InputField, Checkbox, SvgIcon, Loader, Tooltip, Table, ModuleViewHeaderBottom, TooltipSortingFiltering, SuggestInputField, RowActionButtons, Stack, IconButton,
@@ -11,30 +11,34 @@ import useTablePanels from '../hooks/useTablePanels';
 import useTableStore from '../hooks/useTableStore';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const title = __( 'Add New Link' );
+const paginationId = 'kw_id';
+
+const header = {
+	keyword: __( 'Keyword' ),
+	urlLink: __( 'Link' ),
+	lang: __( 'Language' ),
+	kw_priority: __( 'Priority' ),
+	urlFilter: __( 'URL filter' ),
+	kw_length: __( 'Length' ),
+	kwType: __( 'Type' ),
+	kw_usage_count: __( 'Usage' ),
+	labels: __( 'Tags' ),
+};
+const keywordTypes = {
+	M: __( 'Manual' ),
+	I: __( 'Imported' ),
+	X: __( 'None' ),
+};
+
 export default function KeywordsTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add New Link' );
-	const paginationId = 'kw_id';
-
-	const header = {
-		keyword: __( 'Keyword' ),
-		urlLink: __( 'Link' ),
-		lang: __( 'Language' ),
-		kw_priority: __( 'Priority' ),
-		urlFilter: __( 'URL filter' ),
-		kw_length: __( 'Length' ),
-		kwType: __( 'Type' ),
-		kw_usage_count: __( 'Usage' ),
-		labels: __( 'Tags' ),
-	};
-
 	const {
-		columnHelper,
 		data,
 		status,
 		isSuccess,
 		isFetchingNextPage,
 		hasNextPage,
+		columnHelper,
 		ref,
 	} = useInfiniteFetch( { slug } );
 
@@ -43,8 +47,6 @@ export default function KeywordsTable( { slug } ) {
 	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
 	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
 	const setOptions = useTablePanels( ( state ) => state.setOptions );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-	const activePanel = useTablePanels( ( state ) => state.activePanel );
 
 	const setUnifiedPanel = useCallback( ( cell ) => {
 		const origCell = cell?.row.original;
@@ -55,61 +57,17 @@ export default function KeywordsTable( { slug } ) {
 		if ( origCell.kw_usage_count > 0 ) {
 			setOptions( [ {
 				detailsOptions: {
-					title: `Keyword “${ origCell.keyword }” usage`, text: `Keyword “${ origCell.keyword }” used on these URLs`, slug, url: `${ origCell.kw_id }/${ origCell.dest_url_id }`, showKeys: [ { name: [ 'link_type', 'Type' ], size: 30, values: { U: 'Urlslab', E: 'Editor' } }, { name: [ 'url_name', 'URL' ] } ], listId: 'url_id',
+					// translators: %s is generated text, do not change it
+					title: __( 'Keyword %s usage' ).replace( '%s', `“${ origCell.keyword }”` ),
+					// translators: %s is generated text, do not change it
+					text: __( 'Keyword %s used on these URLs' ).replace( '%s', `“${ origCell.keyword }”` ),
+					slug, url: `${ origCell.kw_id }/${ origCell.dest_url_id }`, showKeys: [ { name: [ 'link_type', 'Type' ], size: 30, values: { U: 'Urlslab', E: 'Editor' } }, { name: [ 'url_name', 'URL' ] } ], listId: 'url_id',
 				},
 			} ] );
 		}
 	}, [ setOptions, setRowToEdit, slug, updateRow ] );
 
-	const keywordTypes = useMemo( () => ( {
-		M: __( 'Manual' ),
-		I: __( 'Imported' ),
-		X: __( 'None' ),
-	} ), [ __ ] );
-
-	const rowEditorCells = {
-		keyword: <InputField liveUpdate autoFocus defaultValue="" label={ header.keyword } onChange={ ( val ) => {
-			setRowToEdit( { ...rowToEdit, keyword: val } );
-		} } required description={ __( 'Only exact keyword matches will be substituted with a link' ) } />,
-
-		urlLink: <SuggestInputField suggestInput={ rowToEdit?.keyword || '' }
-									liveUpdate
-									defaultValue={ ( rowToEdit?.urlLink ? rowToEdit?.urlLink : window.location.origin ) }
-									label={ header.urlLink }
-									onChange={ ( val ) => setRowToEdit( { ...rowToEdit, urlLink: val } ) }
-									required
-									showInputAsSuggestion={ true }
-									referenceVal="keyword"
-									description={ __( 'Destination URL' ) } />,
-
-		kwType: <SingleSelectMenu defaultAccept hideOnAdd autoClose items={ keywordTypes } name="kwType" defaultValue="M" description={ __( 'Select the link type if you only want to modify certain kinds of links in HTML' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, kwType: val } ) }>{ header.kwType }</SingleSelectMenu>,
-
-		kw_priority: <InputField liveUpdate type="number" defaultValue="10" min="0" max="100" label={ header.kw_priority }
-								description={ __( 'Input a number between 0 and 100. Lower values indicate higher priority' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, kw_priority: val } ) } />,
-
-		lang: <LangMenu autoClose defaultValue="all"
-						description={ __( 'Keywords only apply to pages in the chosen language' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, lang: val } ) }>{ __( 'Language' ) }</LangMenu>,
-
-		urlFilter: <InputField liveUpdate defaultValue=".*"
-								description={ __( 'Optionally, you can permit keyword placement only on URLs that match a specific regular expression. Use value `.*` to match all URLs' ) }
-			label={ header.urlFilter } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, urlFilter: val } ) } />,
-
-		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, labels: val } ) } />,
-	};
-
-	const rowInserterCells = { ...rowEditorCells };
-	delete rowInserterCells.kwType;
-
 	useEffect( () => {
-		useTablePanels.setState( ( ) => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId, 'dest_url_id' ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -127,30 +85,21 @@ export default function KeywordsTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
-		useTableStore.setState( () => (
-			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
-			}
-		) );
-
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-			}
-		) );
-
-		if ( activePanel === 'rowInserter' ) {
-			useTablePanels.setState( () => (
+			useTableStore.setState( () => (
 				{
-					rowEditorCells: rowInserterCells,
+					tables: {
+						...useTableStore.getState().tables,
+						[ slug ]: {
+							...useTableStore.getState().tables[ slug ],
+							data,
+						},
+					},
 				}
 			) );
-		}
-	}, [ data, slug, activePanel ] );
+	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ ( ) => {
@@ -243,7 +192,7 @@ export default function KeywordsTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ activatePanel, columnHelper, deleteRow, selectRows, setUnifiedPanel, slug, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -252,9 +201,11 @@ export default function KeywordsTable( { slug } ) {
 	return (
 		<>
 			<DescriptionBox	title={ __( 'About this table' ) } tableSlug={ slug } isMainTableDescription>
-				{ __( "The table defines a list of keywords that can be automatically substituted with a link pointing to a defined URL in your website's text, which facilitates large-scale internal link building. This eliminates the need for manually editing individual pages to add links. The plugin leaves all existing page content intact, with modifications only occurring as the page is generated. To reduce the strain on your MySQL database, the link definitions are cached on the server for a few minutes. As a result, changes made to the link definitions may not become visible online until a few minutes have passed." ) }
+				{ __( "The table defines a list of keywords which can be automatically substituted with link pointing to defined URL in your website's text, facilitating large scale internal link building. This eliminates the need for manual editing of individual pages to add links. The plugin leaves all existing page content intact, with modifications only occurring as the page is generated. To reduce the strain on your Mysql database, the link definitions are cached on the server for a few minutes. Consequently, changes made to the link definitions may only be visibly updated online after a few minutes." ) }
 			</DescriptionBox>
+
 			<ModuleViewHeaderBottom />
+
 			<Table className="fadeInto"
 				initialState={ { columnVisibility: { kw_length: false, kwType: false } } }
 				columns={ columns }
@@ -267,6 +218,63 @@ export default function KeywordsTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager slug={ slug } />
 		</>
 	);
 }
+
+const TableEditorManager = memo( ( { slug } ) => {
+	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const activePanel = useTablePanels( ( state ) => state.activePanel );
+
+	const rowEditorCells = useMemo( () => ( {
+		keyword: <InputField liveUpdate autoFocus defaultValue="" label={ header.keyword } onChange={ ( val ) => {
+			setRowToEdit( { keyword: val } );
+		} } required description={ __( 'Only exact keyword matches will be substituted with a link' ) } />,
+
+		urlLink: <SuggestInputField suggestInput={ rowToEdit?.keyword || '' }
+									liveUpdate
+									defaultValue={ ( rowToEdit?.urlLink ? rowToEdit?.urlLink : window.location.origin ) }
+									label={ header.urlLink }
+									onChange={ ( val ) => setRowToEdit( { urlLink: val } ) }
+									required
+									showInputAsSuggestion={ true }
+									referenceVal="keyword"
+									description={ __( 'Destination URL' ) } />,
+
+		kwType: <SingleSelectMenu defaultAccept hideOnAdd autoClose items={ keywordTypes } name="kwType" defaultValue="M" description={ __( 'Select the link type if you only want to modify certain kinds of links in HTML' ) }
+			onChange={ ( val ) => setRowToEdit( { kwType: val } ) }>{ header.kwType }</SingleSelectMenu>,
+
+		kw_priority: <InputField liveUpdate type="number" defaultValue="10" min="0" max="100" label={ header.kw_priority }
+								description={ __( 'Input a number between 0 and 100. Lower values indicate higher priority' ) }
+			onChange={ ( val ) => setRowToEdit( { kw_priority: val } ) } />,
+
+		lang: <LangMenu autoClose defaultValue="all"
+						description={ __( 'Keywords only apply to pages in the chosen language' ) }
+			onChange={ ( val ) => setRowToEdit( { lang: val } ) }>{ __( 'Language' ) }</LangMenu>,
+
+		urlFilter: <InputField liveUpdate defaultValue=".*"
+								description={ __( 'Optionally, you can permit keyword placement only on URLs that match a specific regular expression. Use value `.*` to match all URLs' ) }
+			label={ header.urlFilter } onChange={ ( val ) => setRowToEdit( { urlFilter: val } ) } />,
+
+		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { labels: val } ) } />,
+
+	} ), [ rowToEdit?.keyword, rowToEdit?.urlLink, setRowToEdit, slug ] );
+
+	const rowInserterCells = useMemo( () => {
+		const copy = { ...rowEditorCells };
+		delete copy.kwType;
+		return copy;
+	}, [ rowEditorCells ] );
+
+	useEffect( () => {
+		useTablePanels.setState( ( ) => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells: activePanel === 'rowInserter' ? rowInserterCells : rowEditorCells,
+				deleteCSVCols: [ paginationId, 'dest_url_id' ],
+			}
+		) );
+	}, [ activePanel, rowEditorCells, rowInserterCells ] );
+} );

--- a/admin/src/tables/LinkManagerTable.jsx
+++ b/admin/src/tables/LinkManagerTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useCallback, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch,
@@ -31,11 +31,73 @@ import Stack from '@mui/joy/Stack';
 import Box from '@mui/joy/Box';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const paginationId = 'url_id';
+
+const scrStatusTypes = {
+	N: __( 'Waiting' ),
+	A: __( 'Active' ),
+	P: __( 'Pending' ),
+	U: __( 'Updating' ),
+	E: __( 'Error' ),
+};
+
+const sumStatusTypes = {
+	N: __( 'Waiting' ),
+	A: __( 'Active' ),
+	P: __( 'Pending' ),
+	U: __( 'Updating' ),
+	E: __( 'Error' ),
+};
+
+const httpStatusTypes = {
+	'-2': __( 'Processing' ),
+	'-1': __( 'Waiting' ),
+	200: __( 'Valid' ),
+	400: __( 'Client Error (400)' ),
+	301: __( 'Moved Permanently' ),
+	302: __( 'Found, Moved temporarily' ),
+	307: __( 'Temporary Redirect' ),
+	308: __( 'Permanent Redirect' ),
+	404: __( 'Not Found' ),
+	500: __( 'Server Error (500)' ),
+	503: __( 'Server Error (503)' ),
+};
+
+const visibilityTypes = {
+	V: __( 'Visible' ),
+	H: __( 'Hidden' ),
+};
+
+const header = {
+	url_name: __( 'URL' ),
+	url_title: __( 'Title' ),
+	url_h1: __( 'H1 tag' ),
+	url_meta_description: __( 'Description' ),
+	url_summary: __( 'Summary' ),
+	visibility: __( 'Visibility' ),
+	url_priority: __( 'SEO rank' ),
+	url_links_count: __( 'Outgoing links count' ),
+	url_usage_count: __( 'Incoming links count' ),
+	url_lang: __( 'Language' ),
+	http_status: __( 'HTTP status' ),
+	update_http_date: __( 'HTTP status change' ),
+	scr_status: __( 'Screenshot status' ),
+	update_scr_date: __( 'Screenshot status change' ),
+	sum_status: __( 'Summary status' ),
+	update_sum_date: __( 'Summary status change' ),
+
+	//SERP stats
+	comp_intersections: __( 'Competitors intersection' ),
+	best_position: __( 'Best position' ),
+	top10_queries_cnt: __( 'Top 10' ),
+	top100_queries_cnt: __( 'Top 100' ),
+	top_queries: __( 'Top queries' ),
+	my_urls_ranked_top10: __( 'My URLs ranked Top 10' ),
+	my_urls_ranked_top100: __( 'My URLs ranked Top 100' ),
+
+	labels: __( 'Tags' ),
+};
 export default function LinkManagerTable( { slug } ) {
-	const { __ } = useI18n();
-
-	const paginationId = 'url_id';
-
 	const {
 		columnHelper,
 		data,
@@ -48,17 +110,20 @@ export default function LinkManagerTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const { activatePanel, setOptions, setRowToEdit } = useTablePanels();
-	const showChanges = ( cell ) => {
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const setOptions = useTablePanels( ( state ) => state.setOptions );
+
+	const showChanges = useCallback( ( cell ) => {
 		const { http_status, urlslab_scr_timestamp, urlslab_sum_timestamp, scr_status } = cell?.row?.original;
 		if ( http_status > 299 || http_status <= 0 || scr_status === 'E' || ! scr_status ) {
 			return false;
 		}
 
 		return urlslab_scr_timestamp !== 0 || urlslab_sum_timestamp !== 0;
-	};
+	}, [] );
 
-	const setUnifiedPanel = ( cell ) => {
+	const setUnifiedPanel = useCallback( ( cell ) => {
 		const origCell = cell?.row.original;
 		setOptions( [] );
 		setRowToEdit( {} );
@@ -75,9 +140,9 @@ export default function LinkManagerTable( { slug } ) {
 			},
 		},
 		] );
-	};
+	}, [ setOptions, setRowToEdit, slug ] );
 
-	const ActionButton = ( { cell, onClick } ) => {
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
 		const { http_status } = cell?.row?.original;
 
 		return (
@@ -88,72 +153,7 @@ export default function LinkManagerTable( { slug } ) {
 				</IconButton>
 			</Tooltip>
 		);
-	};
-
-	const scrStatusTypes = {
-		N: __( 'Waiting' ),
-		A: __( 'Active' ),
-		P: __( 'Pending' ),
-		U: __( 'Updating' ),
-		E: __( 'Error' ),
-	};
-
-	const sumStatusTypes = {
-		N: __( 'Waiting' ),
-		A: __( 'Active' ),
-		P: __( 'Pending' ),
-		U: __( 'Updating' ),
-		E: __( 'Error' ),
-	};
-
-	const httpStatusTypes = {
-		'-2': __( 'Processing' ),
-		'-1': __( 'Waiting' ),
-		200: __( 'Valid' ),
-		400: __( 'Client Error (400)' ),
-		301: __( 'Moved Permanently' ),
-		302: __( 'Found, Moved temporarily' ),
-		307: __( 'Temporary Redirect' ),
-		308: __( 'Permanent Redirect' ),
-		404: __( 'Not Found' ),
-		500: __( 'Server Error (500)' ),
-		503: __( 'Server Error (503)' ),
-	};
-
-	const visibilityTypes = {
-		V: __( 'Visible' ),
-		H: __( 'Hidden' ),
-	};
-
-	const header = {
-		url_name: __( 'URL' ),
-		url_title: __( 'Title' ),
-		url_h1: __( 'H1 tag' ),
-		url_meta_description: __( 'Description' ),
-		url_summary: __( 'Summary' ),
-		visibility: __( 'Visibility' ),
-		url_priority: __( 'SEO rank' ),
-		url_links_count: __( 'Outgoing links count' ),
-		url_usage_count: __( 'Incoming links count' ),
-		url_lang: __( 'Language' ),
-		http_status: __( 'HTTP status' ),
-		update_http_date: __( 'HTTP status change' ),
-		scr_status: __( 'Screenshot status' ),
-		update_scr_date: __( 'Screenshot status change' ),
-		sum_status: __( 'Summary status' ),
-		update_sum_date: __( 'Summary status change' ),
-
-		//SERP stats
-		comp_intersections: __( 'Competitors intersection' ),
-		best_position: __( 'Best position' ),
-		top10_queries_cnt: __( 'Top 10' ),
-		top100_queries_cnt: __( 'Top 100' ),
-		top_queries: __( 'Top queries' ),
-		my_urls_ranked_top10: __( 'My URLs ranked Top 10' ),
-		my_urls_ranked_top100: __( 'My URLs ranked Top 100' ),
-
-		labels: __( 'Tags' ),
-	};
+	}, [] );
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -171,16 +171,21 @@ export default function LinkManagerTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -398,7 +403,7 @@ export default function LinkManagerTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ activatePanel, columnHelper, deleteRow, selectRows, setOptions, setUnifiedPanel, showChanges, slug, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/RedirectsTable.jsx
+++ b/admin/src/tables/RedirectsTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 import {
 	useInfiniteFetch,
 	ProgressBar,
@@ -23,11 +23,10 @@ import useRedirectTableMenus from '../hooks/useRedirectTableMenus';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function RedirectsTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add New Redirect' );
-	const paginationId = 'redirect_id';
+const title = __( 'Add New Redirect' );
+const paginationId = 'redirect_id';
 
+export default function RedirectsTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -39,57 +38,9 @@ export default function RedirectsTable( { slug } ) {
 	} = useInfiniteFetch( { slug } );
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
-
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-
 	const { redirectTypes, matchTypes, logginTypes, notFoundTypes, header } = useRedirectTableMenus();
 
-	const rowEditorCells = {
-		match_type: <SingleSelectMenu defaultAccept autoClose items={ matchTypes } name="match_type" defaultValue="E" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_type: val } ) }>{ header.match_type }</SingleSelectMenu>,
-		match_url: <InputField type="url" autoFocus liveUpdate defaultValue="" label={ header.match_url }
-			description={ __( 'Match this value with the browser URL according to the selected rule type' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, match_url: val } ) } required />,
-		replace_url: <SuggestInputField suggestInput={ rowToEdit?.match_url || '' } showInputAsSuggestion={ true } liveUpdate defaultValue={ window.location.origin }
-			referenceVal="match_url"
-			description={ __( 'If the browser URL and all other conditions match, redirect the user to this URL' ) }
-			label={ header.replace_url } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, replace_url: val } ) } required />,
-		redirect_code: <SingleSelectMenu autoClose items={ redirectTypes } name="redirect_code" defaultValue="301"
-			description={ __( 'HTTP status code for visitor redirection' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, redirect_code: val } ) }>{ header.redirect_code }</SingleSelectMenu>,
-		is_logged: <SingleSelectMenu autoClose items={ logginTypes } name="is_logged" defaultValue="A" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, is_logged: val } ) }>{ header.is_logged }</SingleSelectMenu>,
-		headers: <InputField liveUpdate defaultValue="" label={ header.headers }
-			description={ __( 'Redirect only requests with specified HTTP headers sent from the browser. List the headers to be checked, separated by commas. For instance: HEADER-NAME, HEADER-NAME=value' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, headers: val } ) } />,
-		cookie: <InputField liveUpdate defaultValue="" label={ header.cookie }
-			description={ __( 'Redirect only requests with specified cookie sent from the browser. List the cookies to be checked, separated by commas. For instance: COOKIE_NAME, COOKIE_NAME=value' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, cookie: val } ) } />,
-		params: <InputField liveUpdate defaultValue="" label={ header.params }
-			description={ __( 'Redirect only requests with specified GET or POST parameter. List the parameters to be checked, separated by commas. For instance: query-param, query-param=value' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, params: val } ) } />,
-		capabilities: <InputField liveUpdate defaultValue="" label={ header.capabilities }
-			description={ __( 'Redirect only requests from users with certain capabilities' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, capabilities: val } ) } />,
-		ip: <InputField liveUpdate defaultValue="" label={ header.ip }
-			description={ __( 'Redirect only visitors from certain IP addresses or subnets. Provide a comma-separated list of IP addresses or subnets. For instance: 172.120.0.*, 192.168.0.0/24' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, ip: val } ) } />,
-		roles: <InputField liveUpdate defaultValue="" label={ header.roles }
-			description={ __( 'Redirect only requests from users with particular roles' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, roles: val } ) } />,
-		browser: <InputField liveUpdate defaultValue="" label={ header.browser }
-			description={ __( 'Redirect visitors using specific browsers. Input browser names or any string from User-Agent, separated by commas' ) }
-			onChange={ ( val ) => setRowToEdit( { ...rowToEdit, browser: val } ) } />,
-		if_not_found: <SingleSelectMenu autoClose items={ notFoundTypes } name="if_not_found" defaultValue="A" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, if_not_found: val } ) }>{ header.if_not_found }</SingleSelectMenu>,
-		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, labels: val } ) } />,
-	};
-
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -105,18 +56,23 @@ export default function RedirectsTable( { slug } ) {
 				},
 			}
 		) );
-	}, [ slug, rowToEdit ] );
+	}, [ header, slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -235,7 +191,7 @@ export default function RedirectsTable( { slug } ) {
 			header: () => null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow, header.labels, isSelected, logginTypes, matchTypes, notFoundTypes, redirectTypes, selectRows, slug, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -259,6 +215,63 @@ export default function RedirectsTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager slug={ slug } />
 		</>
 	);
 }
+
+const TableEditorManager = memo( ( { slug } ) => {
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
+
+	const { redirectTypes, matchTypes, logginTypes, notFoundTypes, header } = useRedirectTableMenus();
+
+	const rowEditorCells = useMemo( () => ( {
+		match_type: <SingleSelectMenu defaultAccept autoClose items={ matchTypes } name="match_type" defaultValue="E" onChange={ ( val ) => setRowToEdit( { match_type: val } ) }>{ header.match_type }</SingleSelectMenu>,
+		match_url: <InputField type="url" autoFocus liveUpdate defaultValue="" label={ header.match_url }
+			description={ __( 'Match this value with the browser URL according to the selected rule type' ) }
+			onChange={ ( val ) => setRowToEdit( { match_url: val } ) } required />,
+		replace_url: <SuggestInputField suggestInput={ rowToEdit?.match_url || '' } showInputAsSuggestion={ true } liveUpdate defaultValue={ window.location.origin }
+			referenceVal="match_url"
+			description={ __( 'If the browser URL and all other conditions match, redirect the user to this URL' ) }
+			label={ header.replace_url } onChange={ ( val ) => setRowToEdit( { replace_url: val } ) } required />,
+		redirect_code: <SingleSelectMenu autoClose items={ redirectTypes } name="redirect_code" defaultValue="301"
+			description={ __( 'HTTP status code for visitor redirection' ) }
+			onChange={ ( val ) => setRowToEdit( { redirect_code: val } ) }>{ header.redirect_code }</SingleSelectMenu>,
+		is_logged: <SingleSelectMenu autoClose items={ logginTypes } name="is_logged" defaultValue="A" onChange={ ( val ) => setRowToEdit( { is_logged: val } ) }>{ header.is_logged }</SingleSelectMenu>,
+		headers: <InputField liveUpdate defaultValue="" label={ header.headers }
+			description={ __( 'Redirect only requests with specified HTTP headers sent from the browser. List the headers to be checked, separated by commas. For instance: HEADER-NAME, HEADER-NAME=value' ) }
+			onChange={ ( val ) => setRowToEdit( { headers: val } ) } />,
+		cookie: <InputField liveUpdate defaultValue="" label={ header.cookie }
+			description={ __( 'Redirect only requests with specified cookie sent from the browser. List the cookies to be checked, separated by commas. For instance: COOKIE_NAME, COOKIE_NAME=value' ) }
+			onChange={ ( val ) => setRowToEdit( { cookie: val } ) } />,
+		params: <InputField liveUpdate defaultValue="" label={ header.params }
+			description={ __( 'Redirect only requests with specified GET or POST parameter. List the parameters to be checked, separated by commas. For instance: query-param, query-param=value' ) }
+			onChange={ ( val ) => setRowToEdit( { params: val } ) } />,
+		capabilities: <InputField liveUpdate defaultValue="" label={ header.capabilities }
+			description={ __( 'Redirect only requests from users with certain capabilities' ) }
+			onChange={ ( val ) => setRowToEdit( { capabilities: val } ) } />,
+		ip: <InputField liveUpdate defaultValue="" label={ header.ip }
+			description={ __( 'Redirect only visitors from certain IP addresses or subnets. Provide a comma-separated list of IP addresses or subnets. For instance: 172.120.0.*, 192.168.0.0/24' ) }
+			onChange={ ( val ) => setRowToEdit( { ip: val } ) } />,
+		roles: <InputField liveUpdate defaultValue="" label={ header.roles }
+			description={ __( 'Redirect only requests from users with particular roles' ) }
+			onChange={ ( val ) => setRowToEdit( { roles: val } ) } />,
+		browser: <InputField liveUpdate defaultValue="" label={ header.browser }
+			description={ __( 'Redirect visitors using specific browsers. Input browser names or any string from User-Agent, separated by commas' ) }
+			onChange={ ( val ) => setRowToEdit( { browser: val } ) } />,
+		if_not_found: <SingleSelectMenu autoClose items={ notFoundTypes } name="if_not_found" defaultValue="A" onChange={ ( val ) => setRowToEdit( { if_not_found: val } ) }>{ header.if_not_found }</SingleSelectMenu>,
+		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { labels: val } ) } />,
+
+	} ), [ rowToEdit?.match_url, header, logginTypes, setRowToEdit, redirectTypes, matchTypes, notFoundTypes, slug ] );
+
+	useEffect( () => {
+		useTablePanels.setState( ( ) => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+				deleteCSVCols: [ paginationId ],
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/SchedulesTable.jsx
+++ b/admin/src/tables/SchedulesTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch,
@@ -19,11 +19,47 @@ import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 import '../assets/styles/components/_ModuleViewHeader.scss';
 
-export default function SchedulesTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = 'Add Schedule';
-	const paginationId = 'schedule_id';
+const title = __( 'Add Schedule' );
+const paginationId = 'schedule_id';
 
+const followLinksTypes = {
+	FOLLOW_ALL_LINKS: __( 'Process all links (recommended)' ),
+	FOLLOW_NO_LINK: __( 'Don\'t process found links' ),
+};
+const analyzeTextTypes = {
+	1: __( 'Analyze page texts (recommended)' ),
+	0: __( 'Don\'t analyze page texts' ),
+};
+const processSitemapsTypes = {
+	1: __( 'Process all domain sitemaps (recommended)' ),
+	0: __( 'Schedule a single URL only' ),
+};
+const takeScreenshotsTypes = {
+	1: __( 'Capture a screenshot of each page (recommended)' ),
+	0: __( 'Disable screenshot capture' ),
+};
+
+const scanFrequencyTypes = {
+	HOURLY: __( 'Hourly' ),
+	DAILY: __( 'Daily' ),
+	WEEKLY: __( 'Weekly' ),
+	MONTHLY: __( 'Monthly (recommended)' ),
+	YEARLY: __( 'Yearly' ),
+	ONE_TIME: __( 'One Time' ),
+};
+
+const header = {
+	urls: __( 'Domain/URL' ),
+	scan_frequency: __( 'Scan frequency' ),
+	scan_speed_per_minute: __( 'Scan speed (pages per minute)' ),
+	follow_links: __( 'Process found links' ),
+	analyze_text: __( 'Analyze text' ),
+	take_screenshot: __( 'Screenshots' ),
+	process_all_sitemaps: __( 'Domain sitemaps' ),
+	custom_sitemaps: __( 'Sitemap URLs' ),
+};
+
+export default function SchedulesTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -36,63 +72,7 @@ export default function SchedulesTable( { slug } ) {
 
 	const { deleteRow } = useChangeRow();
 
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-
-	const followLinksTypes = {
-		FOLLOW_ALL_LINKS: __( 'Process all links (recommended)' ),
-		FOLLOW_NO_LINK: __( 'Don\'t process found links' ),
-	};
-	const analyzeTextTypes = {
-		1: __( 'Analyze page texts (recommended)' ),
-		0: __( 'Don\'t analyze page texts' ),
-	};
-	const processSitemapsTypes = {
-		1: __( 'Process all domain sitemaps (recommended)' ),
-		0: __( 'Schedule a single URL only' ),
-	};
-	const takeScreenshotsTypes = {
-		1: __( 'Capture a screenshot of each page (recommended)' ),
-		0: __( 'Disable screenshot capture' ),
-	};
-
-	const scanFrequencyTypes = {
-		HOURLY: 'Hourly',
-		DAILY: 'Daily',
-		WEEKLY: 'Weekly',
-		MONTHLY: 'Monthly (recommended)',
-		YEARLY: 'Yearly',
-		ONE_TIME: 'One Time',
-	};
-
-	const header = {
-		urls: __( 'Domain/URL' ),
-		scan_frequency: __( 'Scan frequency' ),
-		scan_speed_per_minute: __( 'Scan speed (pages per minute)' ),
-		follow_links: __( 'Process found links' ),
-		analyze_text: __( 'Analyze text' ),
-		take_screenshot: __( 'Screenshots' ),
-		process_all_sitemaps: __( 'Domain sitemaps' ),
-		custom_sitemaps: __( 'Sitemap URLs' ),
-	};
-	const rowEditorCells = {
-		urls: <InputField liveUpdate defaultValue="" label={ header.urls } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, urls: val } ) } required />,
-		analyze_text: <SingleSelectMenu defaultAccept autoClose items={ analyzeTextTypes } name="analyze_text" defaultValue="1" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, analyze_text: val } ) }>{ header.analyze_text }</SingleSelectMenu>,
-		follow_links: <SingleSelectMenu defaultAccept autoClose items={ followLinksTypes } name="follow_links" defaultValue={ 'FOLLOW_ALL_LINKS' } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, follow_links: val } ) }>{ header.follow_links }</SingleSelectMenu>,
-		process_all_sitemaps: <SingleSelectMenu defaultAccept autoClose items={ processSitemapsTypes } name="process_all" defaultValue="1" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, process_all_sitemaps: val } ) }>{ header.process_all_sitemaps }</SingleSelectMenu>,
-		custom_sitemaps: <InputField liveUpdate defaultValue="" label={ header.custom_sitemaps } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, custom_sitemaps: val } ) } />,
-		take_screenshot: <SingleSelectMenu defaultAccept autoClose items={ takeScreenshotsTypes } name="take_screenshot" defaultValue="1" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, take_screenshot: val } ) }>{ header.take_screenshot }</SingleSelectMenu>,
-		scan_frequency: <SingleSelectMenu defaultAccept autoClose items={ scanFrequencyTypes } name="scan_frequency" defaultValue={ 'MONTHLY' } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, scan_frequency: val } ) }>{ header.scan_frequency }</SingleSelectMenu>,
-		scan_speed_per_minute: <InputField liveUpdate defaultValue="20" label={ header.scan_speed_per_minute } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, scan_speed_per_minute: val } ) } />,
-	};
-
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -111,16 +91,21 @@ export default function SchedulesTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper?.accessor( 'urls', {
 			className: 'nolimit',
 			cell: ( array ) => array?.getValue().map( ( link ) => <><strong>{ link }</strong> </>,
@@ -174,7 +159,7 @@ export default function SchedulesTable( { slug } ) {
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ columnHelper, deleteRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -203,6 +188,32 @@ export default function SchedulesTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager />
 		</>
 	);
 }
+
+const TableEditorManager = memo( () => {
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+
+	const rowEditorCells = useMemo( () => ( {
+		urls: <InputField liveUpdate defaultValue="" label={ header.urls } onChange={ ( val ) => setRowToEdit( { urls: val } ) } required />,
+		analyze_text: <SingleSelectMenu defaultAccept autoClose items={ analyzeTextTypes } name="analyze_text" defaultValue="1" onChange={ ( val ) => setRowToEdit( { analyze_text: val } ) }>{ header.analyze_text }</SingleSelectMenu>,
+		follow_links: <SingleSelectMenu defaultAccept autoClose items={ followLinksTypes } name="follow_links" defaultValue={ 'FOLLOW_ALL_LINKS' } onChange={ ( val ) => setRowToEdit( { follow_links: val } ) }>{ header.follow_links }</SingleSelectMenu>,
+		process_all_sitemaps: <SingleSelectMenu defaultAccept autoClose items={ processSitemapsTypes } name="process_all" defaultValue="1" onChange={ ( val ) => setRowToEdit( { process_all_sitemaps: val } ) }>{ header.process_all_sitemaps }</SingleSelectMenu>,
+		custom_sitemaps: <InputField liveUpdate defaultValue="" label={ header.custom_sitemaps } onChange={ ( val ) => setRowToEdit( { custom_sitemaps: val } ) } />,
+		take_screenshot: <SingleSelectMenu defaultAccept autoClose items={ takeScreenshotsTypes } name="take_screenshot" defaultValue="1" onChange={ ( val ) => setRowToEdit( { take_screenshot: val } ) }>{ header.take_screenshot }</SingleSelectMenu>,
+		scan_frequency: <SingleSelectMenu defaultAccept autoClose items={ scanFrequencyTypes } name="scan_frequency" defaultValue={ 'MONTHLY' } onChange={ ( val ) => setRowToEdit( { scan_frequency: val } ) }>{ header.scan_frequency }</SingleSelectMenu>,
+		scan_speed_per_minute: <InputField liveUpdate defaultValue="20" label={ header.scan_speed_per_minute } onChange={ ( val ) => setRowToEdit( { scan_speed_per_minute: val } ) } />,
+	} ), [ setRowToEdit ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+				deleteCSVCols: [ paginationId ],
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/SchedulesTable.jsx
+++ b/admin/src/tables/SchedulesTable.jsx
@@ -173,9 +173,7 @@ export default function SchedulesTable( { slug } ) {
 			<ModuleViewHeaderBottom
 				noFiltering
 				noCount
-				noExport
-				noImport
-				noDelete
+				hideActions
 			/>
 			<Table className="fadeInto"
 				columns={ columns }

--- a/admin/src/tables/SerpCompetitorsTable.jsx
+++ b/admin/src/tables/SerpCompetitorsTable.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable indent */
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import {
 	useInfiniteFetch,
@@ -18,12 +18,20 @@ import useTablePanels from '../hooks/useTablePanels';
 
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function SerpCompetitorsTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Competitors' );
-	const paginationId = 'domain_id';
-	const defaultSorting = [ { key: 'coverage', dir: 'DESC', op: '<' } ];
+const title = __( 'Competitors' );
+const paginationId = 'domain_id';
 
+const defaultSorting = [ { key: 'coverage', dir: 'DESC', op: '<' } ];
+
+const header = {
+	domain_name: __( 'Domain' ),
+	urls_cnt: __( 'Intersected URLs' ),
+	coverage: __( 'Coverage (%)' ),
+	top10_queries_cnt: __( 'Top 10 queries' ),
+	top100_queries_cnt: __( 'Top 100 queries' ),
+};
+
+export default function SerpCompetitorsTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -33,14 +41,6 @@ export default function SerpCompetitorsTable( { slug } ) {
 		hasNextPage,
 		ref,
 	} = useInfiniteFetch( { slug } );
-
-	const header = {
-		domain_name: __( 'Domain' ),
-		urls_cnt: __( 'Intersected URLs' ),
-		coverage: __( 'Coverage (%)' ),
-		top10_queries_cnt: __( 'Top 10 queries' ),
-		top100_queries_cnt: __( 'Top 100 queries' ),
-	};
 
 	useEffect( () => {
 		useTablePanels.setState( () => (
@@ -66,16 +66,21 @@ export default function SerpCompetitorsTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'domain_name', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <a href={ urlHasProtocol( cell.getValue() ) ? cell.getValue() : `http://${ cell.getValue() }` } target="_blank" rel="noreferrer"><strong>{ cell.getValue() }</strong></a>,
@@ -106,7 +111,7 @@ export default function SerpCompetitorsTable( { slug } ) {
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 50,
 		} ),
-	];
+	], [ columnHelper ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/SerpQueriesTable.jsx
+++ b/admin/src/tables/SerpQueriesTable.jsx
@@ -1,6 +1,5 @@
-/* eslint-disable indent */
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { memo, useCallback, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 import { Link } from 'react-router-dom';
 import Button from '@mui/joy/Button';
 
@@ -33,15 +32,44 @@ import { getTooltipUrlsList } from '../lib/elementsHelpers';
 import DescriptionBox from '../elements/DescriptionBox';
 import { countriesList, countriesListForSelect } from '../api/fetchCountries';
 
+const title = __( 'Add Query' );
+const paginationId = 'query_id';
+const optionalSelector = 'country';
+
+const defaultSorting = [ { key: 'comp_intersections', dir: 'DESC', op: '<' } ];
+
+const statuses = {
+	X: __( 'Not processed' ),
+	P: __( 'Processing' ),
+	A: __( 'Processed' ),
+	E: __( 'Disabled' ),
+	S: __( 'Irrelevant' ),
+};
+
+const types = {
+	U: __( 'User Defined' ),
+	C: __( 'Search Console' ),
+	S: __( 'People also search for' ),
+	F: __( 'People also ask' ),
+};
+
+const header = {
+	query: __( 'Query' ),
+	country: __( 'Country' ),
+	type: __( 'Type' ),
+	status: __( 'Status' ),
+	updated: __( 'Updated' ),
+	comp_intersections: __( 'Competitors in top 10' ),
+	comp_urls: __( 'Competitor URLs' ),
+	my_position: __( 'My Position' ),
+	my_urls: __( 'My URLs' ),
+	my_urls_ranked_top10: __( 'My URLs in Top10' ),
+	my_urls_ranked_top100: __( 'My URLs in Top100' ),
+	internal_links: __( 'Internal Links' ),
+	labels: __( 'Tags' ),
+};
+
 export default function SerpQueriesTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add Query' );
-	const paginationId = 'query_id';
-	const optionalSelector = 'country';
-
-	const { setAIGeneratorConfig } = useAIGenerator();
-	const defaultSorting = [ { key: 'comp_intersections', dir: 'DESC', op: '<' } ];
-
 	const {
 		columnHelper,
 		data,
@@ -55,24 +83,10 @@ export default function SerpQueriesTable( { slug } ) {
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 	const { compareUrls } = useSerpGapCompare( 'query' );
 
-	const { activatePanel, setOptions, setRowToEdit } = useTablePanels();
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-	const { data: modules, isSuccess: isSuccessModules } = useModulesQuery();
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setOptions = useTablePanels( ( state ) => state.setOptions );
 
-	const handleCreateContent = ( keyword ) => {
-		if ( keyword ) {
-			// setting the correct zustand state
-			setAIGeneratorConfig( {
-				keywordsList: [ { q: keyword, checked: true } ],
-				serpUrlsList: [],
-				dataSource: 'SERP_CONTEXT',
-				selectedPromptTemplate: '4',
-				title: keyword,
-			} );
-		}
-	};
-
-	const ActionButton = ( { cell, onClick } ) => {
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
 		const { status: serpStatus } = cell?.row?.original;
 
 		return (
@@ -95,52 +109,9 @@ export default function SerpQueriesTable( { slug } ) {
 				}
 			</div>
 		);
-	};
-
-	const statuses = {
-		X: __( 'Not processed' ),
-		P: __( 'Processing' ),
-		A: __( 'Processed' ),
-		E: __( 'Disabled' ),
-		S: __( 'Irrelevant' ),
-	};
-
-	const types = {
-		U: __( 'User Defined' ),
-		C: __( 'Search Console' ),
-		S: __( 'People also search for' ),
-		F: __( 'People also ask' ),
-	};
-
-	const header = {
-		query: __( 'Query' ),
-		country: __( 'Country' ),
-		type: __( 'Type' ),
-		status: __( 'Status' ),
-		updated: __( 'Updated' ),
-		comp_intersections: __( 'Competitors in top 10' ),
-		comp_urls: __( 'Competitor URLs' ),
-		my_position: __( 'My Position' ),
-		my_urls: __( 'My URLs' ),
-		my_urls_ranked_top10: __( 'My URLs in Top10' ),
-		my_urls_ranked_top100: __( 'My URLs in Top100' ),
-		internal_links: __( 'Internal Links' ),
-		labels: __( 'Tags' ),
-	};
-
-	const rowEditorCells = {
-		query: <TextArea autoFocus liveUpdate defaultValue="" label={ __( 'Queries' ) } rows={ 10 } allowResize onChange={ ( val ) => setRowToEdit( { ...rowToEdit, query: val } ) } required description={ __( 'Each query must be on a separate line' ) } />,
-		country: <InputField liveUpdate autoFocus type="text" defaultValue="" label={ header.country } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, country: val } ) } />,
-		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { ...rowToEdit, labels: val } ) } />,
-	};
+	}, [] );
 
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId, optionalSelector ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
@@ -161,16 +132,21 @@ export default function SerpQueriesTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	//Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
-	}, [ data ] );
+	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ ( ) => {
@@ -185,10 +161,10 @@ export default function SerpQueriesTable( { slug } ) {
 			tooltip: ( cell ) => cell.getValue(),
 			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
 			cell: ( cell ) => <strong className="urlslab-serpPanel-keywords-item"
-								onClick={ () => {
-									setOptions( { queryDetailPanel: { query: cell.row.original.query, country: cell.row.original.country, slug: cell.row.original.query.replace( ' ', '-' ) } } );
-									activatePanel( 'queryDetailPanel' );
-								} }>{ cell.getValue() }</strong>,
+				onClick={ () => {
+					setOptions( { queryDetailPanel: { query: cell.row.original.query, country: cell.row.original.country, slug: cell.row.original.query.replace( ' ', '-' ) } } );
+					activatePanel( 'queryDetailPanel' );
+				} }>{ cell.getValue() }</strong>,
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 175,
 		} ),
@@ -292,44 +268,69 @@ export default function SerpQueriesTable( { slug } ) {
 		} ),
 		columnHelper.accessor( 'editRow', {
 			className: 'editRow',
-			cell: ( cell ) => <RowActionButtons
-				onDelete={ () => deleteRow( { cell, id: 'query' } ) }
-			>
-				{ isSuccessModules && modules.serp.active && ( cell?.row?.original?.my_urls?.length > 0 || cell?.row?.original?.comp_urls?.length > 0 ) && (
-					<Button
-						size="xxs"
-						onClick={ () => compareUrls( cell, [ ...cell.row.original.my_urls, ...cell.row.original.comp_urls ] ) }
-					>
-						{ __( 'Content Gap' ) }
-					</Button>
-				) }
-				{ isSuccessModules && modules[ 'urlslab-generator' ].active && (
-					<Button
-						component={ Link }
-						size="xxs"
-						to="/Generator/generator"
-						onClick={ () => handleCreateContent( cell.row.original.query ) }
-					>
-						{ __( 'Create Content' ) }
-					</Button>
-				) }
-				<Button
-					size="xxs"
-					color="neutral"
-					onClick={ () => {
-							setOptions( { queryDetailPanel: { query: cell.row.original.query, country: cell.row.original.country, slug: cell.row.original.query?.replace( ' ', '-' ) } } );
-							activatePanel( 'queryDetailPanel' );
-						} }
-					sx={ { mr: 1 } }
-				>
-					{ __( 'Show Detail' ) }
-				</Button>
-				<ActionButton cell={ cell } onClick={ ( val ) => updateRow( { changeField: 'status', newVal: val, cell } ) } />
-			</RowActionButtons>,
+			cell: ( cell ) => {
+				const EditRowComponent = () => {
+					// handle generator realted queries inside inner component to prevent unnecessary rerender of parent table component
+					const { data: modules, isSuccess: isSuccessModules } = useModulesQuery();
+					const { setAIGeneratorConfig } = useAIGenerator();
+
+					const handleCreateContent = useCallback( ( keyword ) => {
+						if ( keyword ) {
+							// setting the correct zustand state
+							setAIGeneratorConfig( {
+								keywordsList: [ { q: keyword, checked: true } ],
+								serpUrlsList: [],
+								dataSource: 'SERP_CONTEXT',
+								selectedPromptTemplate: '4',
+								title: keyword,
+							} );
+						}
+					}, [ setAIGeneratorConfig ] );
+
+					return (
+						<RowActionButtons
+							onDelete={ () => deleteRow( { cell, id: 'query' } ) }
+						>
+							{ isSuccessModules && modules.serp.active && ( cell?.row?.original?.my_urls?.length > 0 || cell?.row?.original?.comp_urls?.length > 0 ) && (
+								<Button
+									size="xxs"
+									onClick={ () => compareUrls( cell, [ ...cell.row.original.my_urls, ...cell.row.original.comp_urls ] ) }
+								>
+									{ __( 'Content Gap' ) }
+								</Button>
+							) }
+							{ isSuccessModules && modules[ 'urlslab-generator' ].active && (
+								<Button
+									component={ Link }
+									size="xxs"
+									to="/Generator/generator"
+									onClick={ () => handleCreateContent( cell.row.original.query ) }
+								>
+									{ __( 'Create Content' ) }
+								</Button>
+							) }
+							<Button
+								size="xxs"
+								color="neutral"
+								onClick={ () => {
+									setOptions( { queryDetailPanel: { query: cell.row.original.query, country: cell.row.original.country, slug: cell.row.original.query?.replace( ' ', '-' ) } } );
+									activatePanel( 'queryDetailPanel' );
+								} }
+								sx={ { mr: 1 } }
+							>
+								{ __( 'Show Detail' ) }
+							</Button>
+							<ActionButton cell={ cell } onClick={ ( val ) => updateRow( { changeField: 'status', newVal: val, cell } ) } />
+						</RowActionButtons>
+					);
+				};
+
+				return <EditRowComponent />;
+			},
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ activatePanel, columnHelper, isSelected, compareUrls, deleteRow, selectRows, setOptions, slug, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -353,6 +354,27 @@ export default function SerpQueriesTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager slug={ slug } />
 		</>
 	);
 }
+
+const TableEditorManager = memo( ( slug ) => {
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+
+	const rowEditorCells = useMemo( () => ( {
+		query: <TextArea autoFocus liveUpdate defaultValue="" label={ __( 'Queries' ) } rows={ 10 } allowResize onChange={ ( val ) => setRowToEdit( { query: val } ) } required description={ __( 'Each query must be on a separate line' ) } />,
+		country: <InputField liveUpdate autoFocus type="text" defaultValue="" label={ header.country } onChange={ ( val ) => setRowToEdit( { country: val } ) } />,
+		labels: <TagsMenu optionItem label={ __( 'Tags:' ) } slug={ slug } onChange={ ( val ) => setRowToEdit( { labels: val } ) } />,
+	} ), [ setRowToEdit, slug ] );
+
+	useEffect( () => {
+		useTablePanels.setState( () => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+				deleteCSVCols: [ paginationId, optionalSelector ],
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/SerpQueryDetailSimQueryTable.jsx
+++ b/admin/src/tables/SerpQueryDetailSimQueryTable.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
+
 import { createColumnHelper } from '@tanstack/react-table';
 import { useQuery } from '@tanstack/react-query';
 import useTablePanels from '../hooks/useTablePanels';
@@ -26,37 +27,51 @@ import DescriptionBox from '../elements/DescriptionBox';
 import TableFilters from '../components/TableFilters';
 import useModulesQuery from '../queries/useModulesQuery';
 
+const defaultSorting = [ { key: 'competitors', dir: 'DESC', op: '<' } ];
+
+const header = {
+	query: __( 'Query' ),
+	competitors: __( 'Nr. Intersections' ),
+	matching_urls: __( 'URL Intersections' ),
+	comp_urls: __( 'Comp. URLs' ),
+	my_urls: __( 'My URLs' ),
+	my_min_pos: __( 'My best position' ),
+};
+
 function SerpQueryDetailSimQueryTable( { query, country, slug, handleClose } ) {
-	const { __ } = useI18n();
-	const columnHelper = useMemo( () => createColumnHelper(), [] );
-	const [ queryClusterData, setQueryClusterData ] = useState( { competitorCnt: 2, maxPos: 10 } );
-	const { activatePanel, setOptions } = useTablePanels();
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-	const [ exportStatus, setExportStatus ] = useState();
 	const stopFetching = useRef( false );
-	const defaultSorting = [ { key: 'competitors', dir: 'DESC', op: '<' } ];
+	const columnHelper = useMemo( () => createColumnHelper(), [] );
+
+	const { compareUrls } = useSerpGapCompare( 'query' );
+
+	const [ exportStatus, setExportStatus ] = useState();
+	const [ queryClusterData, setQueryClusterData ] = useState( { competitorCnt: 2, maxPos: 10 } );
+
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setOptions = useTablePanels( ( state ) => state.setOptions );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
 
 	const sorting = useTableStore( ( state ) => state.tables[ slug ]?.sorting || [] );
 	const filters = useTableStore( ( state ) => state.tables[ slug ]?.filters || {} );
 
-	const { data: modules, isSuccess: isSuccessModules } = useModulesQuery();
-	const { compareUrls } = useSerpGapCompare( 'query' );
-
-	const hidePanel = () => {
+	const hidePanel = useCallback( () => {
 		stopFetching.current = true;
-
 		handleClose();
-	};
+	}, [ handleClose ] );
 
-	const handleExportStatus = ( val ) => {
+	const handleExportStatus = useCallback( ( val ) => {
 		setExportStatus( val );
 		if ( val === 100 ) {
 			setTimeout( () => {
 				setExportStatus();
 			}, 1000 );
 		}
-	};
+	}, [] );
+
+	const handleSimKeyClick = useCallback( ( keyword, countryvar ) => {
+		setOptions( { queryDetailPanel: { query: keyword, country: countryvar, slug: keyword.replace( ' ', '-' ) } } );
+		activatePanel( 'queryDetailPanel' );
+	}, [ activatePanel, setOptions ] );
 
 	const { data: similarQueries, isFetching, isSuccess: similarQueriesSuccess } = useQuery( {
 		queryKey: [ slug, query, country, queryClusterData, sorting, filters ],
@@ -72,15 +87,6 @@ function SerpQueryDetailSimQueryTable( { query, country, slug, handleClose } ) {
 			return response;
 		},
 	} );
-
-	const header = {
-		query: __( 'Query' ),
-		competitors: __( 'Nr. Intersections' ),
-		matching_urls: __( 'URL Intersections' ),
-		comp_urls: __( 'Comp. URLs' ),
-		my_urls: __( 'My URLs' ),
-		my_min_pos: __( 'My best position' ),
-	};
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -98,7 +104,7 @@ function SerpQueryDetailSimQueryTable( { query, country, slug, handleClose } ) {
 		) );
 	}, [ slug ] );
 
-	const cols = [
+	const cols = useMemo( () => [
 		columnHelper.accessor( 'query', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <strong className="urlslab-serpPanel-keywords-item"
@@ -169,41 +175,47 @@ function SerpQueryDetailSimQueryTable( { query, country, slug, handleClose } ) {
 		} ),
 		columnHelper.accessor( 'editRow', {
 			className: 'editRow',
-			cell: ( cell ) => <RowActionButtons>
-				{ isSuccessModules && modules.serp.active && ( cell?.row?.original?.my_urls?.length > 0 || cell?.row?.original?.comp_urls?.length > 0 || cell?.row?.original?.matching_urls?.length > 0 ) && (
-					<Button
-						size="xxs"
-						onClick={ () => compareUrls( cell, [ ...cell.row.original.my_urls, ...cell.row.original.comp_urls, ...cell.row.original.matching_urls ] ) }
-					>
-						{ __( 'Content Gap' ) }
-					</Button>
-				)
-				}
-				{
-					<Button
-						component={ Link }
-						to="/KeywordsLinks/keyword"
-						size="xxs"
-						onClick={ () => {
-							setRowToEdit( { ...rowToEdit, keyword: cell?.row?.original?.query, urlLink: cell?.row?.original?.my_urls[ 0 ] } );
-							activatePanel( 'rowInserter' );
-						} }
-						sx={ { mr: 1 } }
-					>
-						{ __( 'Create Link' ) }
-					</Button>
+			cell: ( cell ) => {
+				const EditRowComponent = () => {
+					// handle generator realted queries inside inner component to prevent unnecessary rerender of parent table component
+					const { data: modules, isSuccess: isSuccessModules } = useModulesQuery();
 
-				}
-			</RowActionButtons>,
+					return (
+						<RowActionButtons>
+							{ isSuccessModules && modules.serp.active && ( cell?.row?.original?.my_urls?.length > 0 || cell?.row?.original?.comp_urls?.length > 0 || cell?.row?.original?.matching_urls?.length > 0 ) && (
+								<Button
+									size="xxs"
+									onClick={ () => compareUrls( cell, [ ...cell.row.original.my_urls, ...cell.row.original.comp_urls, ...cell.row.original.matching_urls ] ) }
+								>
+									{ __( 'Content Gap' ) }
+								</Button>
+							)
+							}
+							{
+								<Button
+									component={ Link }
+									to="/KeywordsLinks/keyword"
+									size="xxs"
+									onClick={ () => {
+										setRowToEdit( { keyword: cell?.row?.original?.query, urlLink: cell?.row?.original?.my_urls[ 0 ] } );
+										activatePanel( 'rowInserter' );
+									} }
+									sx={ { mr: 1 } }
+								>
+									{ __( 'Create Link' ) }
+								</Button>
+
+							}
+						</RowActionButtons>
+					);
+				};
+
+				return <EditRowComponent />;
+			},
 			header: null,
 			size: 0,
 		} ),
-	];
-
-	const handleSimKeyClick = ( keyword, countryvar ) => {
-		setOptions( { queryDetailPanel: { query: keyword, country: countryvar, slug: keyword.replace( ' ', '-' ) } } );
-		activatePanel( 'queryDetailPanel' );
-	};
+	], [ activatePanel, columnHelper, compareUrls, handleSimKeyClick, setRowToEdit, slug ] );
 
 	return (
 		<div>

--- a/admin/src/tables/SerpTopDomainsTable.jsx
+++ b/admin/src/tables/SerpTopDomainsTable.jsx
@@ -1,6 +1,5 @@
-/* eslint-disable indent */
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n';
+import { memo, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import {
 	useInfiniteFetch,
@@ -18,12 +17,29 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function SerpTopDomainsTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = __( 'Add Domains' );
-	const paginationId = 'domain_id';
-	const defaultSorting = [ { key: 'top_100_cnt', dir: 'DESC', op: '<' } ];
+const title = __( 'Add Domains' );
+const paginationId = 'domain_id';
 
+const defaultSorting = [ { key: 'top_100_cnt', dir: 'DESC', op: '<' } ];
+
+const domainTypes = {
+	X: __( 'Uncategorized' ),
+	M: __( 'My Domain' ),
+	C: __( 'Competitor' ),
+	I: __( 'Ignored' ),
+};
+const newDomainTypes = {
+	M: __( 'My Domain' ),
+	C: __( 'Competitor' ),
+};
+
+const header = {
+	domain_name: __( 'Domain' ),
+	domain_type: __( 'Type' ),
+	top_100_cnt: __( 'Queries' ),
+};
+
+export default function SerpTopDomainsTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -36,66 +52,40 @@ export default function SerpTopDomainsTable( { slug } ) {
 
 	const { updateRow } = useChangeRow();
 
-	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
-	const rowToEdit = useTablePanels( ( state ) => state.rowToEdit );
-
-	const domainTypes = {
-		X: __( 'Uncategorized' ),
-		M: __( 'My Domain' ),
-		C: __( 'Competitor' ),
-		I: __( 'Ignored' ),
-	};
-	const newDomainTypes = {
-		M: __( 'My Domain' ),
-		C: __( 'Competitor' ),
-	};
-
-	const header = {
-		domain_name: __( 'Domain' ),
-		domain_type: __( 'Type' ),
-		top_100_cnt: __( 'Queries' ),
-	};
-
-	const rowEditorCells = {
-		domain_name: <TextArea autoFocus liveUpdate defaultValue="" label={ __( 'Domains' ) } rows={ 10 } allowResize onChange={ ( val ) => setRowToEdit( { ...rowToEdit, domain_name: val } ) } required description={ __( 'Each domain name must be on a separate line' ) } />,
-		domain_type: <SingleSelectMenu defaultAccept autoClose items={ newDomainTypes } name="domain_type" defaultValue="M" onChange={ ( val ) => setRowToEdit( { ...rowToEdit, domain_type: val } ) }>{ header.domain_type }</SingleSelectMenu>,
-	};
-
 	useEffect( () => {
-		useTablePanels.setState( () => (
-			{
-				rowEditorCells,
-				deleteCSVCols: [ paginationId, 'domain_id' ],
-			}
-		) );
 		useTableStore.setState( () => (
 			{
 				activeTable: slug,
 				tables: {
 					...useTableStore.getState().tables,
 					[ slug ]: {
-				title,
-				paginationId,
-				slug,
-				header,
-				id: 'domain_name',
-				sorting: defaultSorting,
+						title,
+						paginationId,
+						slug,
+						header,
+						id: 'domain_name',
+						sorting: defaultSorting,
 					},
 				},
 			}
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'domain_name', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <a href={ cell.getValue() } target="_blank" rel="noreferrer"><strong>{ cell.getValue() }</strong></a>,
@@ -117,7 +107,7 @@ export default function SerpTopDomainsTable( { slug } ) {
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 50,
 		} ),
-	];
+	], [ columnHelper, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
@@ -140,6 +130,26 @@ export default function SerpTopDomainsTable( { slug } ) {
 					<ProgressBar className="infiniteScroll" value={ ! isFetchingNextPage ? 0 : 100 } />
 				</>
 			</Table>
+			<TableEditorManager />
 		</>
 	);
 }
+
+const TableEditorManager = memo( () => {
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+
+	const rowEditorCells = useMemo( () => ( {
+		domain_name: <TextArea autoFocus liveUpdate defaultValue="" label={ __( 'Domains' ) } rows={ 10 } allowResize onChange={ ( val ) => setRowToEdit( { domain_name: val } ) } required description={ __( 'Each domain name must be on a separate line' ) } />,
+		domain_type: <SingleSelectMenu defaultAccept autoClose items={ newDomainTypes } name="domain_type" defaultValue="M" onChange={ ( val ) => setRowToEdit( { domain_type: val } ) }>{ header.domain_type }</SingleSelectMenu>,
+	} ), [ setRowToEdit ] );
+
+	useEffect( () => {
+		useTablePanels.setState( ( ) => (
+			{
+				...useTablePanels.getState(),
+				rowEditorCells,
+				deleteCSVCols: [ paginationId, 'domain_id' ],
+			}
+		) );
+	}, [ rowEditorCells ] );
+} );

--- a/admin/src/tables/SerpUrlDetailQueryTable.jsx
+++ b/admin/src/tables/SerpUrlDetailQueryTable.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { useI18n } from '@wordpress/react-i18n';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { __ } from '@wordpress/i18n';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useQuery } from '@tanstack/react-query';
 import useTableStore from '../hooks/useTableStore';
@@ -11,27 +11,49 @@ import { postFetch } from '../api/fetching';
 import Loader from '../components/Loader';
 import Table from '../components/TableComponent';
 import { getTooltipUrlsList } from '../lib/elementsHelpers';
-import {RowActionButtons, SortBy} from '../lib/tableImports';
+import { RowActionButtons, SortBy } from '../lib/tableImports';
 import Button from '@mui/joy/Button';
 import ProgressBar from '../elements/ProgressBar';
 import ExportCSVButton from '../elements/ExportCSVButton';
 import ColumnsMenu from '../elements/ColumnsMenu';
 import DescriptionBox from '../elements/DescriptionBox';
 import useSerpGapCompare from '../hooks/useSerpGapCompare';
-import {Link} from "react-router-dom";
-import useModulesQuery from "../queries/useModulesQuery";
-import {countriesList, countriesListForSelect} from "../api/fetchCountries";
+import { Link } from 'react-router-dom';
+import useModulesQuery from '../queries/useModulesQuery';
+import { countriesList, countriesListForSelect } from '../api/fetchCountries';
+import useTablePanels from '../hooks/useTablePanels';
+import useAIGenerator from '../hooks/useAIGenerator';
+
+const defaultSorting = [ { key: 'comp_intersections', dir: 'DESC', op: '<' } ];
+
+const header = {
+	position: __( 'Position' ),
+	query: __( 'Query' ),
+	country: __( 'Country' ),
+	my_urls: __( 'My URLs' ),
+	comp_urls: __( 'Comp. URLs' ),
+	comp_intersections: __( 'Competitors' ),
+	my_position: __( 'My best position' ),
+	my_urls_ranked_top10: __( 'My URLs in Top 10' ),
+	my_urls_ranked_top100: __( 'My URLs in Top 100' ),
+	internal_links: __( 'Internal Links' ),
+};
 
 function SerpUrlDetailQueryTable( { url, slug, handleClose } ) {
-	const { __ } = useI18n();
-	const columnHelper = useMemo( () => createColumnHelper(), [] );
-	const [ exportStatus, setExportStatus ] = useState();
 	const stopFetching = useRef( false );
+	const columnHelper = useMemo( () => createColumnHelper(), [] );
+	const { setAIGeneratorConfig } = useAIGenerator();
+
+	const [ exportStatus, setExportStatus ] = useState();
+
 	const sorting = useTableStore( ( state ) => state.tables[ slug ]?.sorting || [] );
-	const defaultSorting = [ { key: 'comp_intersections', dir: 'DESC', op: '<' } ];
+
 	const { compareUrls } = useSerpGapCompare( 'query' );
-	const { data: modules, isSuccess: isSuccessModules } = useModulesQuery();
-	const handleCreateContent = ( keyword ) => {
+
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setOptions = useTablePanels( ( state ) => state.setOptions );
+
+	const handleCreateContent = useCallback( ( keyword ) => {
 		if ( keyword ) {
 			// setting the correct zustand state
 			setAIGeneratorConfig( {
@@ -42,21 +64,21 @@ function SerpUrlDetailQueryTable( { url, slug, handleClose } ) {
 				title: keyword,
 			} );
 		}
-	};
+	}, [ setAIGeneratorConfig ] );
 
-	const hidePanel = () => {
+	const hidePanel = useCallback( () => {
 		stopFetching.current = true;
 		handleClose();
-	};
+	}, [ handleClose ] );
 
-	const handleExportStatus = ( val ) => {
+	const handleExportStatus = useCallback( ( val ) => {
 		setExportStatus( val );
 		if ( val === 100 ) {
 			setTimeout( () => {
 				setExportStatus();
 			}, 1000 );
 		}
-	};
+	}, [] );
 
 	const { data: similarQueries, isSuccess: similarQueriesSuccess } = useQuery( {
 		queryKey: [ slug, url, sorting ],
@@ -65,19 +87,6 @@ function SerpUrlDetailQueryTable( { url, slug, handleClose } ) {
 			return response.json();
 		},
 	} );
-
-	const header = {
-		position: __( 'Position' ),
-		query: __( 'Query' ),
-		country: __( 'Country' ),
-		my_urls: __( 'My URLs' ),
-		comp_urls: __( 'Comp. URLs' ),
-		comp_intersections: __( 'Competitors' ),
-		my_position: __( 'My best position' ),
-		my_urls_ranked_top10: __( 'My URLs in Top 10' ),
-		my_urls_ranked_top100: __( 'My URLs in Top 100' ),
-		internal_links: __( 'Internal Links' ),
-	};
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -95,7 +104,7 @@ function SerpUrlDetailQueryTable( { url, slug, handleClose } ) {
 		) );
 	}, [ slug ] );
 
-	const cols = [
+	const cols = useMemo( () => [
 		columnHelper.accessor( 'query', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => cell.getValue(),
@@ -176,41 +185,52 @@ function SerpUrlDetailQueryTable( { url, slug, handleClose } ) {
 		} ),
 		columnHelper.accessor( 'editRow', {
 			className: 'editRow',
-			cell: ( cell ) => <RowActionButtons>
-				{ isSuccessModules && modules[ 'serp' ].active && (cell?.row?.original?.my_urls?.length > 0 || cell?.row?.original?.comp_urls?.length > 0) && (
-					<Button
-						size="xxs"
-						onClick={ () => compareUrls( cell, [...cell.row.original.my_urls, ...cell.row.original.comp_urls] ) }
-					>
-						{ __( 'Content Gap' ) }
-					</Button>
-				) }
-				{ isSuccessModules && modules[ 'urlslab-generator' ].active && (
-					<Button
-						component={ Link }
-						size="xxs"
-						to="/Generator/generator"
-						onClick={ () => handleCreateContent( cell.row.original.query ) }
-					>
-						{ __( 'Create Content' ) }
-					</Button>
-				) }
-				<Button
-					size="xxs"
-					color="neutral"
-					onClick={ () => {
-						setOptions( { queryDetailPanel: { query: cell.row.original.query, country: cell.row.original.country, slug: cell.row.original.query?.replace( ' ', '-' ) } } );
-						activatePanel( 'queryDetailPanel' );
-					} }
-					sx={ { mr: 1 } }
-				>
-					{ __( 'Show Detail' ) }
-				</Button>
-			</RowActionButtons>,
+			cell: ( cell ) => {
+				const EditRowComponent = () => {
+					// handle generator realted queries inside inner component to prevent unnecessary rerender of parent table component
+					const { data: modules, isSuccess: isSuccessModules } = useModulesQuery();
+
+					return (
+						<RowActionButtons>
+							{ isSuccessModules && modules.serp.active && ( cell?.row?.original?.my_urls?.length > 0 || cell?.row?.original?.comp_urls?.length > 0 ) && (
+								<Button
+									size="xxs"
+									onClick={ () => compareUrls( cell, [ ...cell.row.original.my_urls, ...cell.row.original.comp_urls ] ) }
+								>
+									{ __( 'Content Gap' ) }
+								</Button>
+							) }
+							{ isSuccessModules && modules[ 'urlslab-generator' ].active && (
+								<Button
+									component={ Link }
+									size="xxs"
+									to="/Generator/generator"
+									onClick={ () => handleCreateContent( cell.row.original.query ) }
+								>
+									{ __( 'Create Content' ) }
+								</Button>
+							) }
+							<Button
+								size="xxs"
+								color="neutral"
+								onClick={ () => {
+									setOptions( { queryDetailPanel: { query: cell.row.original.query, country: cell.row.original.country, slug: cell.row.original.query?.replace( ' ', '-' ) } } );
+									activatePanel( 'queryDetailPanel' );
+								} }
+								sx={ { mr: 1 } }
+							>
+								{ __( 'Show Detail' ) }
+							</Button>
+						</RowActionButtons>
+					);
+				};
+
+				return <EditRowComponent />;
+			},
 			header: null,
 			size: 0,
 		} ),
-	];
+	], [ activatePanel, columnHelper, compareUrls, handleCreateContent, setOptions, slug ] );
 
 	return (
 		<div>

--- a/admin/src/tables/SerpUrlDetailSimilarUrlsTable.jsx
+++ b/admin/src/tables/SerpUrlDetailSimilarUrlsTable.jsx
@@ -19,14 +19,14 @@ import ColumnsMenu from '../elements/ColumnsMenu';
 import DescriptionBox from '../elements/DescriptionBox';
 
 const defaultSorting = [ { key: 'cnt_queries', dir: 'DESC', op: '<' } ];
-/*
+
 const domainTypes = {
 	X: __( 'Uncategorized' ),
 	M: __( 'My Domain' ),
 	C: __( 'Competitor' ),
 	I: __( 'Ignored' ),
 };
-*/
+
 const header = {
 	url_name: __( 'URL' ),
 	cnt_queries: __( 'Intersections' ),

--- a/admin/src/tables/SerpUrlDetailSimilarUrlsTable.jsx
+++ b/admin/src/tables/SerpUrlDetailSimilarUrlsTable.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { useI18n } from '@wordpress/react-i18n';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { __ } from '@wordpress/i18n';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useQuery } from '@tanstack/react-query';
 
@@ -18,29 +18,44 @@ import ExportCSVButton from '../elements/ExportCSVButton';
 import ColumnsMenu from '../elements/ColumnsMenu';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const defaultSorting = [ { key: 'cnt_queries', dir: 'DESC', op: '<' } ];
+/*
+const domainTypes = {
+	X: __( 'Uncategorized' ),
+	M: __( 'My Domain' ),
+	C: __( 'Competitor' ),
+	I: __( 'Ignored' ),
+};
+*/
+const header = {
+	url_name: __( 'URL' ),
+	cnt_queries: __( 'Intersections' ),
+	top10_queries_cnt: __( 'Top 10 Queries' ),
+	top100_queries_cnt: __( 'Top 100 Queries' ),
+};
+
 function SerpUrlDetailSimilarUrlsTable( { url, slug, handleClose } ) {
-	const { __ } = useI18n();
-	const columnHelper = useMemo( () => createColumnHelper(), [] );
-	const [ exportStatus, setExportStatus ] = useState();
 	const stopFetching = useRef( false );
-	const sorting = useTableStore( ( state ) => state.tables[ slug ]?.sorting || [] );
-	const defaultSorting = [ { key: 'cnt_queries', dir: 'DESC', op: '<' } ];
+	const columnHelper = useMemo( () => createColumnHelper(), [] );
+
 	const [ popupTableType, setPopupTableType ] = useState( 'A' );
+	const [ exportStatus, setExportStatus ] = useState();
 
-	const hidePanel = () => {
+	const sorting = useTableStore( ( state ) => state.tables[ slug ]?.sorting || [] );
+
+	const hidePanel = useCallback( () => {
 		stopFetching.current = true;
-
 		handleClose();
-	};
+	}, [ handleClose ] );
 
-	const handleExportStatus = ( val ) => {
+	const handleExportStatus = useCallback( ( val ) => {
 		setExportStatus( val );
 		if ( val === 100 ) {
 			setTimeout( () => {
 				setExportStatus();
 			}, 1000 );
 		}
-	};
+	}, [] );
 
 	const { data: similarQueries, isSuccess: UrlsSuccess } = useQuery( {
 		queryKey: [ slug, url, sorting, popupTableType ],
@@ -49,20 +64,6 @@ function SerpUrlDetailSimilarUrlsTable( { url, slug, handleClose } ) {
 			return response.json();
 		},
 	} );
-
-	const domainTypes = {
-		X: __( 'Uncategorized' ),
-		M: __( 'My Domain' ),
-		C: __( 'Competitor' ),
-		I: __( 'Ignored' ),
-	};
-
-	const header = {
-		url_name: __( 'URL' ),
-		cnt_queries: __( 'Intersections' ),
-		top10_queries_cnt: __( 'Top 10 Queries' ),
-		top100_queries_cnt: __( 'Top 100 Queries' ),
-	};
 
 	useEffect( () => {
 		useTableStore.setState( () => (
@@ -80,7 +81,7 @@ function SerpUrlDetailSimilarUrlsTable( { url, slug, handleClose } ) {
 		) );
 	}, [ slug ] );
 
-	const cols = [
+	const cols = useMemo( () => [
 		columnHelper.accessor( 'url_name', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <a href={ cell.getValue() } target="_blank" rel="noreferrer">{ cell.getValue() }</a>,
@@ -109,7 +110,7 @@ function SerpUrlDetailSimilarUrlsTable( { url, slug, handleClose } ) {
 			header: ( th ) => <SortBy { ...th } customSlug={ slug } />,
 			minSize: 50,
 		} ),
-	];
+	], [ columnHelper, slug ] );
 
 	return (
 		<div>

--- a/admin/src/tables/SerpUrlsTable.jsx
+++ b/admin/src/tables/SerpUrlsTable.jsx
@@ -1,6 +1,5 @@
-/* eslint-disable indent */
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 
 import {
 	useInfiniteFetch,
@@ -19,12 +18,33 @@ import { getTooltipList } from '../lib/elementsHelpers';
 import Button from '@mui/joy/Button';
 import DescriptionBox from '../elements/DescriptionBox';
 
+const title = '';
+const paginationId = 'url_id';
+
+const defaultSorting = [ { key: 'top10_queries_cnt', dir: 'DESC', op: '<' } ];
+
+const domainTypes = {
+	X: __( 'Uncategorized' ),
+	M: __( 'My Domain' ),
+	C: __( 'Competitor' ),
+	I: __( 'Ignored' ),
+};
+
+const header = {
+	url_name: __( 'URL' ),
+	url_title: __( 'Title' ),
+	url_description: __( 'Description' ),
+	domain_type: __( 'Domain type' ),
+	comp_intersections: __( 'Competitors' ),
+	best_position: __( 'Best position' ),
+	top10_queries_cnt: __( 'Top 10' ),
+	top100_queries_cnt: __( 'Top 100' ),
+	top_queries: __( 'Top queries' ),
+	my_urls_ranked_top10: __( 'My URLs in Top10' ),
+	my_urls_ranked_top100: __( 'My URLs in Top100' ),
+};
+
 export default function SerpUrlsTable( { slug } ) {
-	const { __ } = useI18n();
-	const title = '';
-	const paginationId = 'url_id';
-	const defaultSorting = [ { key: 'top10_queries_cnt', dir: 'DESC', op: '<' } ];
-	const { activatePanel, setOptions } = useTablePanels();
 	const {
 		columnHelper,
 		data,
@@ -35,26 +55,8 @@ export default function SerpUrlsTable( { slug } ) {
 		ref,
 	} = useInfiniteFetch( { slug } );
 
-	const domainTypes = {
-		X: __( 'Uncategorized' ),
-		M: __( 'My Domain' ),
-		C: __( 'Competitor' ),
-		I: __( 'Ignored' ),
-	};
-
-	const header = {
-		url_name: __( 'URL' ),
-		url_title: __( 'Title' ),
-		url_description: __( 'Description' ),
-		domain_type: __( 'Domain type' ),
-		comp_intersections: __( 'Competitors' ),
-		best_position: __( 'Best position' ),
-		top10_queries_cnt: __( 'Top 10' ),
-		top100_queries_cnt: __( 'Top 100' ),
-		top_queries: __( 'Top queries' ),
-		my_urls_ranked_top10: __( 'My URLs in Top10' ),
-		my_urls_ranked_top100: __( 'My URLs in Top100' ),
-	};
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setOptions = useTablePanels( ( state ) => state.setOptions );
 
 	useEffect( () => {
 		useTablePanels.setState( () => (
@@ -80,16 +82,21 @@ export default function SerpUrlsTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'url_name', {
 			tooltip: ( cell ) => cell.getValue(),
 			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
@@ -177,7 +184,7 @@ export default function SerpUrlsTable( { slug } ) {
 			size: 0,
 		} ),
 
-	];
+	], [ activatePanel, columnHelper, setOptions, slug ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/UsageTable.jsx
+++ b/admin/src/tables/UsageTable.jsx
@@ -99,9 +99,7 @@ export default function UsageTable( { slug } ) {
 			<ModuleViewHeaderBottom
 				noFiltering
 				noCount
-				noExport
-				noImport
-				noDelete
+				hideActions
 			/>
 			<Table className="fadeInto"
 				columns={ columns }

--- a/admin/src/tables/UsageTable.jsx
+++ b/admin/src/tables/UsageTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 import {
 	useInfiniteFetch,
 	Loader,
@@ -12,25 +12,25 @@ import {
 import useTableStore from '../hooks/useTableStore';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
+
 import '../assets/styles/components/_ModuleViewHeader.scss';
 
-export default function UsageTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'id';
+const paginationId = 'id';
 
+const header = {
+	groupBucketTitle: __( 'Date' ),
+	creditType: __( 'Type' ),
+	events: __( 'Count' ),
+	credits: __( 'Usage' ),
+};
+
+export default function UsageTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
 		status,
 		isSuccess,
 	} = useInfiniteFetch( { slug }, 500 );
-
-	const header = {
-		groupBucketTitle: __( 'Date' ),
-		creditType: __( 'Type' ),
-		events: __( 'Count' ),
-		credits: __( 'Usage' ),
-	};
 
 	useEffect( () => {
 		useTablePanels.setState( () => (
@@ -53,16 +53,21 @@ export default function UsageTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'groupBucketTitle', {
 			cell: ( cell ) => <DateTimeFormat noTime datetime={ cell.getValue() } />,
 			header: header.groupBucketTitle,
@@ -80,7 +85,7 @@ export default function UsageTable( { slug } ) {
 			header: header.credits,
 			size: 100,
 		} ),
-	];
+	], [ columnHelper ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;

--- a/admin/src/tables/YouTubeCacheTable.jsx
+++ b/admin/src/tables/YouTubeCacheTable.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useI18n } from '@wordpress/react-i18n/';
+import { useCallback, useEffect, useMemo } from 'react';
+import { __ } from '@wordpress/i18n/';
 import {
 	useInfiniteFetch, ProgressBar, SortBy, Tooltip, Checkbox, Loader, Table, ModuleViewHeaderBottom, TooltipSortingFiltering, SvgIcon, IconButton, RowActionButtons, DateTimeFormat, Stack,
 } from '../lib/tableImports';
@@ -10,10 +10,27 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 
-export default function YouTubeCacheTable( { slug } ) {
-	const { __ } = useI18n();
-	const paginationId = 'videoid';
+const paginationId = 'videoid';
 
+const statusTypes = {
+	N: __( 'New' ),
+	A: __( 'Available' ),
+	P: __( 'Processing' ),
+	D: __( 'Disabled' ),
+};
+
+const header = {
+	thumb: __( 'Thumbnail' ),
+	videoid: __( 'YouTube video ID' ),
+	title: __( 'Title' ),
+	captions: __( 'Captions' ),
+	status: __( 'Status' ),
+	usage_count: __( 'Usage' ),
+	status_changed: __( 'Changed' ),
+	microdata: __( 'Youtube microdata JSON' ),
+};
+
+export default function YouTubeCacheTable( { slug } ) {
 	const {
 		columnHelper,
 		data,
@@ -26,8 +43,11 @@ export default function YouTubeCacheTable( { slug } ) {
 
 	const { isSelected, selectRows, deleteRow, updateRow } = useChangeRow();
 
-	const { activatePanel, setRowToEdit, setOptions } = useTablePanels();
-	const setUnifiedPanel = ( cell ) => {
+	const activatePanel = useTablePanels( ( state ) => state.activatePanel );
+	const setRowToEdit = useTablePanels( ( state ) => state.setRowToEdit );
+	const setOptions = useTablePanels( ( state ) => state.setOptions );
+
+	const setUnifiedPanel = useCallback( ( cell ) => {
 		const origCell = cell?.row.original;
 		setOptions( [] );
 		setRowToEdit( {} );
@@ -39,9 +59,9 @@ export default function YouTubeCacheTable( { slug } ) {
 				},
 			} ] );
 		}
-	};
+	}, [ setOptions, setRowToEdit, slug ] );
 
-	const ActionButton = ( { cell, onClick } ) => {
+	const ActionButton = useMemo( () => ( { cell, onClick } ) => {
 		const { status: videoStatus } = cell?.row?.original;
 
 		return (
@@ -72,25 +92,7 @@ export default function YouTubeCacheTable( { slug } ) {
 				}
 			</div>
 		);
-	};
-
-	const statusTypes = {
-		N: __( 'New' ),
-		A: __( 'Available' ),
-		P: __( 'Processing' ),
-		D: __( 'Disabled' ),
-	};
-
-	const header = {
-		thumb: __( 'Thumbnail' ),
-		videoid: __( 'YouTube video ID' ),
-		title: __( 'Title' ),
-		captions: __( 'Captions' ),
-		status: __( 'Status' ),
-		usage_count: __( 'Usage' ),
-		status_changed: __( 'Changed' ),
-		microdata: __( 'Youtube microdata JSON' ),
-	};
+	}, [] );
 
 	useEffect( () => {
 		useTablePanels.setState( () => (
@@ -113,16 +115,21 @@ export default function YouTubeCacheTable( { slug } ) {
 		) );
 	}, [ slug ] );
 
-	// Saving all variables into state managers
 	useEffect( () => {
 		useTableStore.setState( () => (
 			{
-				tables: { ...useTableStore.getState().tables, [ slug ]: { ...useTableStore.getState().tables[ slug ], data } },
+				tables: {
+					...useTableStore.getState().tables,
+					[ slug ]: {
+						...useTableStore.getState().tables[ slug ],
+						data,
+					},
+				},
 			}
 		) );
 	}, [ data, slug ] );
 
-	const columns = [
+	const columns = useMemo( () => [
 		columnHelper.accessor( 'check', {
 			className: 'checkbox',
 			cell: ( cell ) => <Checkbox defaultValue={ isSelected( cell ) } onChange={ () => {
@@ -204,7 +211,7 @@ export default function YouTubeCacheTable( { slug } ) {
 			size: 0,
 		} ),
 
-	];
+	], [ activatePanel, columnHelper, deleteRow, selectRows, setUnifiedPanel, updateRow ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
1) Fixed unwanted rerenders of table component under table panel.
Closing, opening and working witn user inputs inside table related panels have to be instant without table rerenders, related panels: Add/Edit row, more actions panels.

2) fixed Redirect creation from 404 table, not necessary rerender and read of table component.
Added optional `customSubmitAction` prop that process custom actions on popup submit - in this case create redirect from 404 without necessary load of Redirect table in 404 table popup.

3) Table components:
-- extracted fixed objects outside table components to prevent necessary use as deps in effects.
-- extracted table rows with related panel actions into separated component to prevent whole table component rerenders on panel actions
-- where possible, moved use of custom query hooks into nested component to prevent main table component reload (ie. `SerpQueriesTable`, `useAIGenerator()` used and handled only in edit row.)

**TODO:** In SERP tables needs to be refactored `useSerpGapCompare` hook that still cause rerenders of table from detail panel.

Close QualityUnit/web-issues#2142
