### PR TITLE
fix: SQL when no urls enetered was incorrect, validator will solve it

### DIFF
--- a/includes/api/class-urlslab-api-serp-gap.php
+++ b/includes/api/class-urlslab-api-serp-gap.php
@@ -82,14 +82,6 @@ class Urlslab_Api_Serp_Gap extends Urlslab_Api_Table {
 			}
 		}
 
-		if ( empty( $urls ) ) {
-			$no_sql = new Urlslab_Api_Table_Sql( $request );
-			$no_sql->add_select_column( 'NULL' );
-
-			return $no_sql;
-		}
-
-
 		$hash_id = Urlslab_Data_Kw_Intersections::compute_hash_id( $request->get_param( 'urls' ) );
 		$task_id = get_transient( 'urlslab_kw_intersections_' . $hash_id );
 


### PR DESCRIPTION
This PR will solve the problem, but we don't need the check for empty urls on this place - it should be done with proper validator
https://github.com/QualityUnit/wp-urlslab/pull/1274

Close https://github.com/QualityUnit/web-issues/issues/2181
