### PR TITLE
fix: domain_type parameter for similar-urls and count query

### DIFF
--- a/admin/src/tables/SerpUrlDetailSimilarUrlsTable.jsx
+++ b/admin/src/tables/SerpUrlDetailSimilarUrlsTable.jsx
@@ -44,7 +44,7 @@ function SerpUrlDetailSimilarUrlsTable( { url } ) {
 
 	const [ popupTableType, setPopupTableType ] = useState( 'A' );
 
-	const customFetchOptions = { url };
+	const customFetchOptions = { url, domain_type: popupTableType };
 
 	const { data: similarQueries, status, isSuccess: UrlsSuccess, isFetchingNextPage,
 		hasNextPage, ref } = useInfiniteFetch( { slug, customFetchOptions, defaultSorting }, 20 );

--- a/includes/api/class-urlslab-api-serp-urls.php
+++ b/includes/api/class-urlslab-api-serp-urls.php
@@ -132,7 +132,7 @@ class Urlslab_Api_Serp_Urls extends Urlslab_Api_Table {
 			'op'  => '=',
 			'val' => $url->get_url_id(),
 		);
-		if ( strlen( $request->get_param( 'domain_type' ) ) ) {
+		if ( strlen( $request->get_param( 'domain_type' ) ) && 'A' !== $request->get_param( 'domain_type' ) ) {
 			$body['filters'][] = array(
 				'col' => 'domain_type',
 				'op'  => '=',

--- a/includes/cron/class-urlslab-cron-serp-volumes.php
+++ b/includes/cron/class-urlslab-cron-serp-volumes.php
@@ -78,7 +78,7 @@ class Urlslab_Cron_Serp_Volumes extends Urlslab_Cron {
 		$query_data[] = Urlslab_Data_Serp_Query::get_now();
 		$rows         = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT * FROM ' . URLSLAB_SERP_QUERIES_TABLE . ' WHERE status=%s ' . $status_cond . ' AND country_scheduled<%s LIMIT 100', // phpcs:ignore
+				'SELECT * FROM ' . URLSLAB_SERP_QUERIES_TABLE . ' WHERE status=%s ' . $status_cond . ' AND (country_scheduled<%s OR country_scheduled IS NULL) LIMIT 100', // phpcs:ignore
 				$query_data
 			),
 			ARRAY_A


### PR DESCRIPTION
**Changes proposed in this Pull Request**
`domain_type` parameter for `similar-urls` and `count` query in SERP Url detail

Close QualityUnit/web-issues#2243
