### PR TITLE
fix: empty string object key in select input

### DIFF
--- a/admin/src/elements/SingleSelectMenu.jsx
+++ b/admin/src/elements/SingleSelectMenu.jsx
@@ -69,7 +69,7 @@ export default function SingleSelectMenu( {
 					<ul className={ `urlslab-MultiSelectMenu__items--inn ${ Object.values( items ).length > 8 ? 'has-scrollbar' : '' }` }>
 						{ Object.entries( items ).map( ( [ id, value ] ) => {
 							// check type of option key to return wanted type and pass type check with 'checked' value
-							const optionKey = isNaN( id ) ? id : +id;
+							const optionKey = id === '' || isNaN( id ) ? id : +id;
 							return (
 								<li
 									key={ optionKey }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed selection of select option which is represented with empty string key like `System Default` below:
```
export const queryScheduleIntervals = {
	D: __( 'Daily' ),
	W: __( 'Weekly' ),
	M: __( 'Monthly' ),
	Y: __( 'Yearly' ),
	O: __( 'Once' ),
	'': __( 'System Default' ),
};
```

Close QualityUnit/web-issues#2332
