### PR TITLE
fix: query and url detail tables

### DIFF
--- a/admin/src/components/detailsPanel/QueryDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/QueryDetailPanel.jsx
@@ -1,4 +1,4 @@
-import { memo, Suspense, lazy, useState } from 'react';
+import { memo, Suspense, lazy, useState, useEffect, useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import useTableStore from '../../hooks/useTableStore';
@@ -6,7 +6,7 @@ import useTableStore from '../../hooks/useTableStore';
 import TableDetailsMenu from '../TableDetailsMenu';
 import BackButton from '../../elements/BackButton';
 import '../../assets/styles/components/_TableDetail.scss';
-import {countriesList} from "../../api/fetchCountries";
+import { countriesList } from '../../api/fetchCountries';
 
 const SerpQueryDetailRankedUrlsTable = lazy( () => import( '../../tables/SerpQueryDetailRankedUrlsTable' ) );
 const SerpQueryDetailClusterUrlsTable = lazy( () => import( '../../tables/SerpQueryDetailClusterUrlsTable' ) );
@@ -18,10 +18,25 @@ const detailMenu = {
 	rankedurls: __( 'Top100 URLs' ),
 };
 
-function QueryDetailPanel( { handleBack } ) {
+function QueryDetailPanel( { sourceTableSlug } ) {
 	const queryDetailPanel = useTableStore( ( state ) => state.queryDetailPanel );
+	const setQueryDetailPanel = useTableStore( ( state ) => state.setQueryDetailPanel );
+	const setActiveTable = useTableStore( ( state ) => state.setActiveTable );
 	const { query, country } = queryDetailPanel;
 	const [ activeSection, setActiveSection ] = useState( 'kwcluster' );
+
+	const handleBack = useCallback( () => {
+		setQueryDetailPanel( null );
+		setActiveTable( sourceTableSlug );
+	}, [ setActiveTable, setQueryDetailPanel, sourceTableSlug ] );
+
+	// manage panel states on unmount
+	useEffect( () => {
+		return () => {
+			console.log( 'unmount' );
+			handleBack();
+		};
+	}, [ handleBack ] );
 
 	return (
 		<div className="urlslab-tableDetail">
@@ -31,7 +46,7 @@ function QueryDetailPanel( { handleBack } ) {
 						{ __( 'Back To Queries' ) }
 					</BackButton>
 					<h3 className="urlslab-tableDetail-title" key={ `${ query }(${ country })` }>
-						{ query } ({ countriesList[country] })
+						{ query } ({ countriesList[ country ] })
 					</h3>
 				</div>
 				<TableDetailsMenu menu={ detailMenu } activeSection={ activeSection } activateSection={ ( val ) => setActiveSection( val ) } />

--- a/admin/src/components/detailsPanel/QueryDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/QueryDetailPanel.jsx
@@ -33,7 +33,6 @@ function QueryDetailPanel( { sourceTableSlug } ) {
 	// manage panel states on unmount
 	useEffect( () => {
 		return () => {
-			console.log( 'unmount' );
 			handleBack();
 		};
 	}, [ handleBack ] );

--- a/admin/src/components/detailsPanel/UrlDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/UrlDetailPanel.jsx
@@ -1,4 +1,4 @@
-import { memo, lazy, Suspense, useState } from 'react';
+import { memo, lazy, Suspense, useState, useEffect, useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import useTableStore from '../../hooks/useTableStore';
@@ -15,16 +15,26 @@ const detailMenu = {
 	urls: __( 'Similar URLs' ),
 };
 
-function UrlDetailPanel( { handleClose } ) {
-	const { url } = useTableStore( ( state ) => state.urlDetailPanel );
+function UrlDetailPanel( { sourceTableSlug } ) {
+	const urlDetailPanel = useTableStore( ( state ) => state.urlDetailPanel );
+	const setUrlDetailPanel = useTableStore( ( state ) => state.setUrlDetailPanel );
+	const setActiveTable = useTableStore( ( state ) => state.setActiveTable );
+
+	const { url } = urlDetailPanel;
 	const [ activeSection, setActiveSection ] = useState( 'queries' );
 
-	const handleBack = () => {
-		handleClose();
-		const cleanState = { ...useTableStore.getState() };
-		delete cleanState.urlDetailPanel;
-		useTableStore.setState( { cleanState } );
-	};
+	const handleBack = useCallback( () => {
+		setUrlDetailPanel( null );
+		setActiveTable( sourceTableSlug );
+	}, [ setActiveTable, setUrlDetailPanel, sourceTableSlug ] );
+
+	// manage panel states on unmount
+	useEffect( () => {
+		return () => {
+			console.log( 'unmount' );
+			handleBack();
+		};
+	}, [ handleBack ] );
 
 	return (
 		<div className="urlslab-tableDetail">

--- a/admin/src/components/detailsPanel/UrlDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/UrlDetailPanel.jsx
@@ -31,7 +31,6 @@ function UrlDetailPanel( { sourceTableSlug } ) {
 	// manage panel states on unmount
 	useEffect( () => {
 		return () => {
-			console.log( 'unmount' );
 			handleBack();
 		};
 	}, [ handleBack ] );

--- a/admin/src/hooks/useTableStore.jsx
+++ b/admin/src/hooks/useTableStore.jsx
@@ -15,6 +15,8 @@ const useTableStore = create( ( set ) => ( {
 	setSelectedRows: ( selectedRows ) => set( ( ) => ( { selectedRows } ) ),
 	setFilters: ( filters, customSlug ) => set( ( state ) => ( { tables: { ...state.tables, [ customSlug ? customSlug : state.activeTable ]: { ...state.tables[ customSlug ? customSlug : state.activeTable ], filters } } } ) ),
 	setSorting: ( sorting, customSlug ) => set( ( state ) => ( { tables: { ...state.tables, [ customSlug ? customSlug : state.activeTable ]: { ...state.tables[ customSlug ? customSlug : state.activeTable ], sorting } } } ) ),
+	setQueryDetailPanel: ( ( queryDetailPanel ) => set( ( state ) => ( { ...state, queryDetailPanel } ) ) ),
+	setUrlDetailPanel: ( ( urlDetailPanel ) => set( ( state ) => ( { ...state, urlDetailPanel } ) ) ),
 } ) );
 
 export default useTableStore;

--- a/admin/src/tables/SerpUrlsTable.jsx
+++ b/admin/src/tables/SerpUrlsTable.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, lazy, Suspense } from 'react';
+import { useEffect, useMemo, lazy, Suspense } from 'react';
 import { __ } from '@wordpress/i18n/';
 import { urlHeaders, domainTypes } from '../lib/serpUrlColumns';
 
@@ -35,8 +35,8 @@ export default function SerpUrlsTable( { slug } ) {
 		ref,
 	} = useInfiniteFetch( { slug, defaultSorting } );
 
-	const setActiveTable = useTableStore( ( state ) => state.setActiveTable );
-	const [ urlDetail, setUrlDetail ] = useState( false );
+	const urlDetailPanel = useTableStore( ( state ) => state.urlDetailPanel );
+	const setUrlDetailPanel = useTableStore( ( state ) => state.setUrlDetailPanel );
 
 	useEffect( () => {
 		useTablePanels.setState( () => (
@@ -80,8 +80,7 @@ export default function SerpUrlsTable( { slug } ) {
 			tooltip: ( cell ) => cell.getValue(),
 			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
 			cell: ( cell ) => <strong className="urlslab-serpPanel-keywords-item" onClick={ () => {
-				useTableStore.setState( { urlDetailPanel: { url: cell.row.original.url_name, slug } } );
-				setUrlDetail( true );
+				setUrlDetailPanel( { url: cell.row.original.url_name, slug } );
 			} }>{ cell.getValue() }</strong>,
 			header: ( th ) => <SortBy { ...th } />,
 			minSize: 200,
@@ -163,8 +162,7 @@ export default function SerpUrlsTable( { slug } ) {
 					size="xxs"
 					color="neutral"
 					onClick={ () => {
-						useTableStore.setState( { urlDetailPanel: { url: cell.row.original.url_name, slug } } );
-						setUrlDetail( true );
+						setUrlDetailPanel( { url: cell.row.original.url_name, slug } );
 					} }
 					sx={ { mr: 1 } }
 				>
@@ -175,14 +173,14 @@ export default function SerpUrlsTable( { slug } ) {
 			size: 0,
 		} ),
 
-	], [ columnHelper, slug ] );
+	], [ columnHelper, slug, setUrlDetailPanel ] );
 
 	if ( status === 'loading' ) {
 		return <Loader isFullscreen />;
 	}
 
 	return (
-		! urlDetail
+		! urlDetailPanel
 			? <>
 				<DescriptionBox	title={ __( 'About this table' ) } tableSlug={ slug } isMainTableDescription>
 					{ __( "The table displays URLs that are ranked among the top 100 results in SERP. Next to each URL, you have the option to examine the key queries associated with each URL and the number of competitor domains intersecting with it for the same keywords. The more your URL intersects with those of your competitors, the greater its potential significance to your business. This report also provides ideas drawn from your competitors' websites on what a well-ranked page should look like. It can serve as a source of inspiration, helping you identify what type of content may be missing from your own website." ) }
@@ -204,9 +202,7 @@ export default function SerpUrlsTable( { slug } ) {
 				</Table>
 			</>
 			: <Suspense>
-				<UrlDetailPanel handleClose={ () => {
-					setUrlDetail( false ); setActiveTable( slug );
-				} } />
+				<UrlDetailPanel sourceTableSlug={ slug } />
 			</Suspense>
 	);
 }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Querys and URLs detail tables management.
Detail states cleared on unmount using effect cleanup function, so states are reseted even the user left table other way than click on back button.

Close QualityUnit/web-issues#2362
