### PR TITLE
fix: word combination prefill with all values

### DIFF
--- a/admin/src/hooks/useSerpGapCompare.jsx
+++ b/admin/src/hooks/useSerpGapCompare.jsx
@@ -39,7 +39,7 @@ export default function useSerpGapCompare( queryCol, slug = 'serp-gap' ) {
 			show_keyword_cluster,
 			country,
 			parse_headers,
-			ngrams: [],
+			ngrams: [ 1, 2, 3, 4, 5 ],
 
 			// data for urls preprocessing
 			forceUrlsProcessing: true, // run preprocessing immediately with passed data


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Prefill words combination option with all values when come from Queries table.

Close QualityUnit/web-issues#2336
