### PR TITLE
Content gap fixes

### DIFF
--- a/admin/src/app/mui_joy/theme.js
+++ b/admin/src/app/mui_joy/theme.js
@@ -46,14 +46,6 @@ export const urlslabTheme = extendTheme( {
 				background: {
 					body: '#edeff3',
 				},
-				primary: {
-					solidDisabledColor: 'var(--urlslab-palette-primary-solidColor)',
-					softDisabledColor: 'var(--urlslab-palette-primary-solidColor)',
-				},
-				warning: {
-					solidDisabledColor: 'var(--urlslab-palette-warning-solidColor)',
-					softDisabledColor: 'var(--urlslab-palette-warning-solidColor)',
-				},
 				success: {
 					plainColor: 'var(--urlslab-palette-saturated-green)',
 					solidBg: 'var(--urlslab-palette-saturated-green)',

--- a/admin/src/assets/styles/layouts/ContentGapTableCells.scss
+++ b/admin/src/assets/styles/layouts/ContentGapTableCells.scss
@@ -17,6 +17,7 @@
 			width: 50%;
 			display: flex;
 			justify-content: center;
+			line-height: 1;
 
 			&-words {
 				color: $white;

--- a/admin/src/components/detailsPanel/GapDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/GapDetailPanel.jsx
@@ -342,7 +342,7 @@ function GapDetailPanel( { slug } ) {
 								</Tooltip>
 							</FormControl>
 
-							{ ( fetchOptions.query && fetchOptions.show_keyword_cluster ) &&
+							{ ( fetchOptions.show_keyword_cluster ) &&
 								<Stack direction="row" spacing={ 1 } >
 									<FormControl sx={ { marginBottom: 1, width: '50%' } }>
 										<FormLabel>{ __( 'Clustering level' ) }</FormLabel>

--- a/admin/src/components/detailsPanel/GapDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/GapDetailPanel.jsx
@@ -1,30 +1,21 @@
-import { createContext, memo, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { createContext, memo, useCallback, useEffect, useRef, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import Button from '@mui/joy/Button';
 
 import useTablePanels from '../../hooks/useTablePanels';
-import { getQueryUrls } from '../../lib/serpQueries';
-
-import SvgIcon from '../../elements/SvgIcon';
-import IconButton from '../../elements/IconButton';
-import CountrySelect from '../../elements/CountrySelect';
-import MultiSelectBox from '../../elements/MultiSelectBox';
 
 import Box from '@mui/joy/Box';
-import FormControl from '@mui/joy/FormControl';
-import FormLabel from '@mui/joy/FormLabel';
-import Input from '@mui/joy/Input';
-import Stack from '@mui/joy/Stack';
-import Tooltip from '@mui/joy/Tooltip';
-import MuiCheckbox from '@mui/joy/Checkbox';
-import MuiIconButton from '@mui/joy/IconButton';
-import CircularProgress from '@mui/joy/CircularProgress';
 
 import { emptyUrls, preprocessUrls } from '../../lib/serpContentGapHelpers';
-import { MainWrapper, SettingsWrapper } from '../styledComponents/gapDetail';
+import { MainWrapper } from '../styledComponents/gapDetail';
+import GapDetailMainSettings from './gapDetailPanelParts/GapDetailMainSettings';
+import GapDetailUrlsSettings from './gapDetailPanelParts/GapDetailUrlsSettings';
 
-const maxGapUrls = 15;
-const parseHeadersValues = {
+// option keys that trigger necessary urls preprocess on next options submit
+const processingTriggers = [ 'ngrams', 'parse_headers', 'urls' ];
+
+export const maxGapUrls = 15;
+export const parseHeadersValues = {
 	title: __( 'Title' ),
 	h1: 'H1',
 	h2: 'H2',
@@ -35,12 +26,8 @@ const parseHeadersValues = {
 	p: __( 'Paragraphs' ),
 };
 
-const ngramsValues = [ 1, 2, 3, 4, 5 ];
-
-// option keys that trigger necessary urls preprocess on next options submit
-const processingTriggers = [ 'ngrams', 'parse_headers', 'urls' ];
-
-const ContentGapContext = createContext( {} );
+export const ngramsValues = [ 1, 2, 3, 4, 5 ];
+export const ContentGapContext = createContext( {} );
 
 function GapDetailPanel() {
 	const preprocessController = useRef( null );
@@ -124,20 +111,6 @@ function GapDetailPanel() {
 		updateFetchOptions();
 	}, [ contentGapOptions.willProcessing, runProcessing, setContentGapOptions, updateFetchOptions ] );
 
-	const loadUrls = useCallback( async ( ) => {
-		setLoadingUrls( true );
-		const queryUrls = await getQueryUrls( { query: contentGapOptions.query, country: contentGapOptions.country, limit: maxGapUrls } );
-
-		if ( queryUrls ) {
-			const indexedUrlsList = {};
-			Object.values( queryUrls ).forEach( ( value, index ) => {
-				indexedUrlsList[ `url_${ index }` ] = value.url_name;
-			} );
-			setContentGapOptions( { urls: indexedUrlsList, forceUrlsProcessing: true } );
-		}
-		setLoadingUrls( false );
-	}, [ contentGapOptions.country, contentGapOptions.query, setContentGapOptions ] );
-
 	useEffect( () => {
 		if ( contentGapOptions.forceUrlsProcessing ) {
 			runProcessing();
@@ -145,430 +118,28 @@ function GapDetailPanel() {
 	}, [ contentGapOptions.forceUrlsProcessing, runProcessing ] );
 
 	return (
-		<ContentGapContext.Provider value={ { contentGapOptions, updateOptions } }>
+		<ContentGapContext.Provider value={ { loadingUrls, setLoadingUrls, updateOptions } }>
 			<Box sx={ ( theme ) => ( { backgroundColor: theme.vars.palette.common.white, padding: '1em 1.625em', borderBottom: `1px solid ${ theme.vars.palette.divider }` } ) }>
 
 				<MainWrapper>
-
-					<SettingsWrapper>
-
-						<Box>
-							<Stack spacing={ 1 }>
-
-								<FormControl >
-									<FormLabel flexNoWrap textNoWrap>
-										{ __( 'Query' ) }
-										<Tooltip
-											//title={ __( '' ) }
-											placement="bottom"
-										>
-											<Box>
-												<IconButton className="ml-s info-grey">
-													<SvgIcon name="info" />
-												</IconButton>
-											</Box>
-										</Tooltip>
-									</FormLabel>
-									<Input
-										value={ contentGapOptions.query }
-										onChange={ ( event ) => updateOptions( { query: event.target.value } ) }
-										// simulate our liveUpdate, until custom mui Input component isn't available
-										//onChange={ ( event ) => delay( () => updateOptions( { query: event.target.value } ), 800 )() }
-										//onBlur={ ( event ) => event.target.value !== contentGapOptions.query ? updateOptions( event.target.value ) : null }
-										sx={ ( theme ) => ( {
-											width: 250,
-											[ theme.breakpoints.between( 'xl', 'xxl' ) ]: {
-												width: '100%',
-											},
-										} ) }
-									/>
-								</FormControl>
-
-								<FormControl >
-									<FormLabel>{ __( 'Country' ) }</FormLabel>
-									<CountrySelect
-										key={ contentGapOptions.country }
-										value={ contentGapOptions.country }
-										onChange={ ( val ) => updateOptions( { country: val } ) }
-										inputStyles={ ( theme ) => ( {
-											width: 250,
-											[ theme.breakpoints.between( 'xl', 'xxl' ) ]: {
-												width: '100%',
-											},
-										} ) }
-									/>
-								</FormControl>
-
-								<div className="flex flex-justify-end limit">
-									<Button
-										variant="soft"
-										disabled={ ! contentGapOptions.query }
-										onClick={ loadUrls }
-										loading={ loadingUrls }
-										wider
-									>
-										{ __( 'Load URLs' ) }
-									</Button>
-								</div>
-							</Stack>
-						</Box>
-
-						<Box>
-							<Stack spacing={ 1 }>
-								<FormControl>
-									<FormLabel flexNoWrap textNoWrap>
-										{ __( 'Parse text from' ) }
-										<Tooltip
-											title={
-												<>
-													<strong>{ __( 'How parsing works?' ) }</strong>
-													<p>{ __( 'Text elements from specified URLs will be extracted and compared for phrase matching. Checking this box allows for parsing text strictly from headers, i.e. H1 … H5 tags, and TITLE tags. This is a useful option as copywriters often use the most important keywords in titles and headers, thus enabling the identification of keyword frequency based on headings alone.' ) }</p>
-												</>
-											}
-											placement="bottom"
-											sx={ { maxWidth: '45rem' } }
-										>
-											<Box>
-												<IconButton className="ml-s info-grey">
-													<SvgIcon name="info" />
-												</IconButton>
-											</Box>
-										</Tooltip>
-									</FormLabel>
-									<Box>
-										<MultiSelectBox
-											items={ parseHeadersValues }
-											selected={ contentGapOptions.parse_headers }
-											onChange={ ( value ) => updateOptions( { parse_headers: value } ) }
-											fitItems
-										/>
-									</Box>
-
-								</FormControl>
-								<FormControl>
-									<FormLabel flexNoWrap textNoWrap>
-										{ __( 'Word combinations' ) }
-										<Tooltip
-											title={ __( 'The "n-grams" field specifies the maximum number of words that are grouped together to form a compound keyword for search queries. For instance: 1-gram (unigram) consists of a single word (e.g., "apple"), a 2-gram (bigram) incorporates a pair of words (e.g., "fresh apple"), etc.' ) }
-											placement="bottom"
-											sx={ { maxWidth: '45rem' } }
-										>
-											<Box>
-												<IconButton className="ml-s info-grey">
-													<SvgIcon name="info" />
-												</IconButton>
-											</Box>
-										</Tooltip>
-									</FormLabel>
-									<Box>
-										<MultiSelectBox
-											items={ ngramsValues }
-											selected={ contentGapOptions.ngrams }
-											onChange={ ( value ) => updateOptions( { ngrams: value } ) }
-											fitItems
-											fitWidth
-										/>
-									</Box>
-
-								</FormControl>
-								<FormControl orientation="horizontal">
-									<MuiCheckbox
-										size="sm"
-										checked={ contentGapOptions.show_keyword_cluster }
-										onChange={ ( event ) => updateOptions( { show_keyword_cluster: event.target.checked } ) }
-										label={ __( 'Show just queries from Keyword Cluster' ) }
-										sx={ ( theme ) => ( { color: theme.palette.urlslabColors.greyDarker } ) }
-										textNoWrap
-									/>
-									<Tooltip
-										title={
-											<>
-												<strong>{ __( 'What is keyword cluster?' ) }</strong>
-												<p>{ __( 'Cluster forms keywords discovered in your database, where the same URLs rank on Google Search for each query.' ) }</p>
-												<p>{ __( 'Based on entered query we identify all other best matching keywords from the cluster.' ) }</p>
-												<p>{ __( 'If this option is selected, keywords included in page, but not found in SERP data will not be included in the table.' ) }</p>
-											</>
-										}
-										placement="bottom"
-										sx={ { maxWidth: '45rem' } }
-									>
-										<Box>
-											<IconButton className="ml-s info-grey">
-												<SvgIcon name="info" />
-											</IconButton>
-										</Box>
-									</Tooltip>
-								</FormControl>
-
-								<FormControl orientation="horizontal" >
-									<MuiCheckbox
-										size="sm"
-										checked={ contentGapOptions.compare_domains }
-										onChange={ ( event ) => updateOptions( { compare_domains: event.target.checked } ) }
-										label={ __( 'Compare domains of URLs' ) }
-										sx={ ( theme ) => ( { color: theme.palette.urlslabColors.greyDarker } ) }
-										textNoWrap
-									/>
-									<Tooltip
-										title={
-											<>
-												<strong>{ __( 'How does domain comparison work?' ) }</strong>
-												<p>{ __( 'From given URLs we extract domain name and compare from those domains all queries where given domain rank in top positions on Google. Evaluated are just processed queries, more queries your process, better results you get (e.g. 10k queries recommended). If we discover, that for given domain ranks better other URL of the domain (for specific query), we will show notification about it. This could help you to identify other URLs of domain, which rank better as select URL. This information could be helpful if you are building content clusters to identify duplicate pages with same intent or new opportunities found in competitor website. If you select this option, computation will take much longer as significantly more queries needs to be considered.' ) }</p>
-											</>
-										}
-										placement="bottom"
-										sx={ { maxWidth: '45rem' } }
-									>
-										<Box>
-											<IconButton className="ml-s info-grey">
-												<SvgIcon name="info" />
-											</IconButton>
-										</Box>
-									</Tooltip>
-								</FormControl>
-
-								{ ( contentGapOptions.show_keyword_cluster ) &&
-									<Stack direction="row" spacing={ 1 } >
-										<FormControl sx={ { marginBottom: 1 } }>
-											<FormLabel>{ __( 'Clustering level' ) }</FormLabel>
-											<Input
-												type="number"
-												defaultValue={ contentGapOptions.matching_urls }
-												onChange={ ( event ) => updateOptions( { matching_urls: event.target.value } ) }
-												// simulate our liveUpdate, until custom mui Input component isn't available
-												//onChange={ ( event ) => delay( () => setLupdateOptionsocalOptions( { matching_urls: event.target.value } ), 800 )() }
-												//onBlur={ ( event ) => event.target.value !== contentGapOptions.matching_urls ? updateOptions( { matching_urls: event.target.value } ) : null }
-												sx={ { width: 160 } }
-											/>
-										</FormControl>
-										<FormControl sx={ { marginBottom: 1 } }>
-											<FormLabel>{ __( 'Max position' ) }</FormLabel>
-											<Input
-												type="number"
-												defaultValue={ contentGapOptions.max_position }
-												onChange={ ( event ) => updateOptions( { max_position: event.target.value } ) }
-												// simulate our liveUpdate, until custom mui Input component isn't available
-												//onChange={ ( event ) => delay( () => updateOptions( { max_position: event.target.value } ), 800 )() }
-												//onBlur={ ( event ) => event.target.value !== contentGapOptions.max_position ? updateOptions( { max_position: event.target.value } ) : null }
-												sx={ { width: 160 } }
-											/>
-										</FormControl>
-									</Stack>
-								}
-							</Stack>
-						</Box>
-
-					</SettingsWrapper>
-
-					<Box className="limit flex">
-
-						{ ! loadingUrls
-							? <GapUrlsManager urls={ contentGapOptions.urls } onChange={ ( newUrls ) => updateOptions( { urls: newUrls } ) } />
-							: <Box className="limit flex flex-align-center flex-justify-center">
-								<CircularProgress />
-							</Box>
-						}
-
-					</Box>
-
+					<GapDetailMainSettings />
+					<GapDetailUrlsSettings />
 				</MainWrapper>
+
 				{ showSubmitButton() &&
-				<Box display="flex" sx={ { paddingTop: '1em' } }>
-					<Button
-						disabled={ false }
-						onClick={ runUpdateResults }
-						wider
-					>
-						{ __( 'Update Results' ) }
-					</Button>
-				</Box>
+					<Box display="flex" sx={ { paddingTop: '1em' } }>
+						<Button
+							disabled={ false }
+							onClick={ runUpdateResults }
+							wider
+						>
+							{ __( 'Update Results' ) }
+						</Button>
+					</Box>
 				}
 			</Box>
 		</ContentGapContext.Provider>
 	);
 }
-
-const GapUrlsManager = memo( () => {
-	const { contentGapOptions, updateOptions } = useContext( ContentGapContext );
-	const isMaxUrls = maxGapUrls <= Object.keys( contentGapOptions.urls ).length;
-
-	const addNewInput = useCallback( () => {
-		const newUrl = { [ `url_${ Object.keys( contentGapOptions.urls ).length }` ]: '' };
-		updateOptions( { urls: { ...contentGapOptions.urls, ...newUrl } } );
-	}, [ contentGapOptions.urls, updateOptions ] );
-
-	return (
-		<Box className="limit">
-			<Stack direction="row" flexWrap="wrap">
-
-				{ Object.keys( contentGapOptions.urls ).length > 0 &&
-					<>
-						{
-							Object.entries( contentGapOptions.urls ).map( ( [ key, url ] ) => (
-								<ColumnWrapper key={
-									// make sure to rerender inputs after change of their count, ie. after remove
-									`${ key }-${ Object.keys( contentGapOptions.urls ).length }`
-								}>
-									<UrlOption index={ key } url={ url } />
-								</ColumnWrapper>
-							) )
-						}
-					</>
-				}
-				<ColumnWrapper>
-					<Button
-						color="neutral"
-						variant="soft"
-						disabled={ isMaxUrls }
-						onClick={ addNewInput }
-						startDecorator={ ! isMaxUrls && <SvgIcon name="plus" /> }
-						sx={ ( theme ) => ( {
-							width: '100%',
-							'--Icon-fontSize': theme.vars.fontSize.sm,
-						} ) }
-					>
-						{ isMaxUrls
-							? (
-							// translators: %i is generated number, do not change it
-								__( 'Max %i URLs allowed' ).replace( '%i', maxGapUrls )
-							)
-							: __( 'Add another URL' )
-						}
-					</Button>
-				</ColumnWrapper>
-			</Stack>
-		</Box>
-	);
-} );
-
-const UrlOption = memo( ( { index, url } ) => {
-	const { contentGapOptions, updateOptions } = useContext( ContentGapContext );
-	const processedUrls = contentGapOptions.processedUrls;
-	const processingUrls = contentGapOptions.processingUrls;
-	const urls = contentGapOptions.urls;
-
-	const processedUrlData = processedUrls[ index ];
-	const isError = processedUrlData && processedUrlData.status === 'error';
-	const title = `${ __( 'URL' ) } ${ +index.replace( 'url_', '' ) + 1 }`;
-
-	const removeUrl = useCallback( ( urlKey ) => {
-		const newUrls = {};
-		const newProcessedUrls = {};
-		let customIndex = 0;
-		Object.entries( urls ).forEach( ( [ key, value ] ) => {
-			if ( urlKey !== key ) {
-				newUrls[ `url_${ customIndex }` ] = value;
-				customIndex++;
-			}
-		} );
-		customIndex = 0;
-		Object.entries( processedUrls ).forEach( ( [ key, value ] ) => {
-			if ( urlKey !== key ) {
-				newProcessedUrls[ `url_${ customIndex }` ] = value;
-				customIndex++;
-			}
-		} );
-		updateOptions( { urls: newUrls, processedUrls: newProcessedUrls } );
-	}, [ processedUrls, updateOptions, urls ] );
-
-	const updateUrl = useCallback( ( newValue, urlKey ) => {
-		const newUrls = { ...urls };
-		newUrls[ urlKey ] = newValue;
-		updateOptions( { urls: newUrls } );
-	}, [ updateOptions, urls ] );
-
-	return (
-		<FormControl
-			orientation="horizontal"
-			sx={ { justifyContent: 'flex-end' } }
-		>
-			<FormLabel
-				textNoWrap
-				sx={ { width: 65 } }
-			>{ title }</FormLabel>
-			<Tooltip
-				color={ isError ? 'danger' : 'neutral' }
-				title={
-					( processedUrlData && processedUrlData.status === 'error' )
-						? <>{ processedUrlData.message }<br />{ url }</>
-						: url
-				}
-			>
-				<Input
-					className="limit"
-					defaultValue={ url }
-					onChange={ ( event ) => updateUrl( event.target.value, index ) }
-					// simulate our liveUpdate, until custom mui Input component isn't available
-					//onChange={ ( event ) => delay( () => updateUrl( event.target.value, key ), 800 )() }
-					//onBlur={ ( event ) => event.target.value !== url ? updateUrl( event.target.value, key ) : null }
-					startDecorator={
-						<>
-							{ processingUrls &&
-								<MuiIconButton
-									size="xs"
-									variant="soft"
-									color="neutral"
-									sx={ { pointerEvents: 'none' } }
-								>
-									<CircularProgress size="sm" sx={ { '--CircularProgress-size': '17px', '--CircularProgress-thickness': '2px' } } />
-								</MuiIconButton>
-							}
-
-							{ ( ! processingUrls && processedUrlData && processedUrlData.status === 'error' ) &&
-								<MuiIconButton
-									size="xs"
-									variant="soft"
-									color="danger"
-									sx={ { pointerEvents: 'none' } }
-								>
-									<SvgIcon name="disable" />
-								</MuiIconButton>
-							}
-							{ ( ! processingUrls && processedUrlData && processedUrlData.status === 'ok' ) &&
-								<MuiIconButton
-									size="xs"
-									variant="soft"
-									color="success"
-									sx={ { pointerEvents: 'none' } }
-								>
-									<SvgIcon name="checkmark-circle" />
-								</MuiIconButton>
-							}
-						</>
-					}
-				/>
-			</Tooltip>
-			{
-				Object.keys( urls ).length > 1 &&
-					<IconButton className="ml-s info-grey-darker" onClick={ () => removeUrl( index ) }>
-						<Tooltip title={
-							// translators: %s is generated text, do not change it
-							__( 'Remove %s' ).replace( '%s', title )
-						} >
-							<Box display="flex" alignItems="center">
-								<SvgIcon name="minus-circle" />
-							</Box>
-						</Tooltip>
-					</IconButton>
-			}
-		</FormControl>
-	);
-} );
-
-const ColumnWrapper = memo( ( { children } ) => (
-	<Box sx={ ( theme ) => ( {
-		mb: 1, pr: 2,
-		width: 340,
-		[ theme.breakpoints.down( 'xxxl' ) ]: {
-			width: '50%',
-		},
-		[ theme.breakpoints.down( 'xl' ) ]: {
-			width: '33.3%',
-		},
-		[ theme.breakpoints.down( 'lg' ) ]: {
-			width: '50%',
-		},
-	} ) }>{ children }</Box>
-) );
 
 export default memo( GapDetailPanel );

--- a/admin/src/components/detailsPanel/GapDetailPanel.jsx
+++ b/admin/src/components/detailsPanel/GapDetailPanel.jsx
@@ -170,7 +170,6 @@ function GapDetailPanel() {
 										</Tooltip>
 									</FormLabel>
 									<Input
-										//key={ contentGapOptions.query }
 										value={ contentGapOptions.query }
 										onChange={ ( event ) => updateOptions( { query: event.target.value } ) }
 										// simulate our liveUpdate, until custom mui Input component isn't available

--- a/admin/src/components/detailsPanel/gapDetailPanelParts/GapDetailMainSettings.jsx
+++ b/admin/src/components/detailsPanel/gapDetailPanelParts/GapDetailMainSettings.jsx
@@ -1,0 +1,256 @@
+import { memo, useCallback, useContext } from 'react';
+import { __ } from '@wordpress/i18n';
+import Button from '@mui/joy/Button';
+
+import useTablePanels from '../../../hooks/useTablePanels';
+import { getQueryUrls } from '../../../lib/serpQueries';
+
+import SvgIcon from '../../../elements/SvgIcon';
+import IconButton from '../../../elements/IconButton';
+import CountrySelect from '../../../elements/CountrySelect';
+import MultiSelectBox from '../../../elements/MultiSelectBox';
+
+import Box from '@mui/joy/Box';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
+import Tooltip from '@mui/joy/Tooltip';
+import MuiCheckbox from '@mui/joy/Checkbox';
+
+import { SettingsWrapper } from '../../styledComponents/gapDetail';
+import { ContentGapContext, maxGapUrls, ngramsValues, parseHeadersValues } from '../GapDetailPanel';
+
+function GapDetailMainSettings() {
+	const { loadingUrls, setLoadingUrls, updateOptions } = useContext( ContentGapContext );
+	const contentGapOptions = useTablePanels( ( state ) => state.contentGapOptions );
+	const setContentGapOptions = useTablePanels( ( state ) => state.setContentGapOptions );
+
+	const loadUrls = useCallback( async ( ) => {
+		setLoadingUrls( true );
+		const queryUrls = await getQueryUrls( { query: contentGapOptions.query, country: contentGapOptions.country, limit: maxGapUrls } );
+
+		if ( queryUrls ) {
+			const indexedUrlsList = {};
+			Object.values( queryUrls ).forEach( ( value, index ) => {
+				indexedUrlsList[ `url_${ index }` ] = value.url_name;
+			} );
+			setContentGapOptions( { urls: indexedUrlsList, forceUrlsProcessing: true } );
+		}
+		setLoadingUrls( false );
+	}, [ contentGapOptions.country, contentGapOptions.query, setContentGapOptions, setLoadingUrls ] );
+
+	return (
+		<SettingsWrapper>
+
+			<Box>
+				<Stack spacing={ 1 }>
+
+					<FormControl >
+						<FormLabel flexNoWrap textNoWrap>
+							{ __( 'Query' ) }
+							<Tooltip
+								//title={ __( '' ) }
+								placement="bottom"
+							>
+								<Box>
+									<IconButton className="ml-s info-grey">
+										<SvgIcon name="info" />
+									</IconButton>
+								</Box>
+							</Tooltip>
+						</FormLabel>
+						<Input
+							value={ contentGapOptions.query }
+							onChange={ ( event ) => updateOptions( { query: event.target.value } ) }
+							// simulate our liveUpdate, until custom mui Input component isn't available
+							//onChange={ ( event ) => delay( () => updateOptions( { query: event.target.value } ), 800 )() }
+							//onBlur={ ( event ) => event.target.value !== contentGapOptions.query ? updateOptions( event.target.value ) : null }
+							sx={ ( theme ) => ( {
+								width: 250,
+								[ theme.breakpoints.between( 'xl', 'xxl' ) ]: {
+									width: '100%',
+								},
+							} ) }
+						/>
+					</FormControl>
+
+					<FormControl >
+						<FormLabel>{ __( 'Country' ) }</FormLabel>
+						<CountrySelect
+							key={ contentGapOptions.country }
+							value={ contentGapOptions.country }
+							onChange={ ( val ) => updateOptions( { country: val } ) }
+							inputStyles={ ( theme ) => ( {
+								width: 250,
+								[ theme.breakpoints.between( 'xl', 'xxl' ) ]: {
+									width: '100%',
+								},
+							} ) }
+						/>
+					</FormControl>
+
+					<div className="flex flex-justify-end limit">
+						<Button
+							variant="soft"
+							disabled={ ! contentGapOptions.query }
+							onClick={ loadUrls }
+							loading={ loadingUrls }
+							wider
+						>
+							{ __( 'Load URLs' ) }
+						</Button>
+					</div>
+				</Stack>
+			</Box>
+
+			<Box>
+				<Stack spacing={ 1 }>
+					<FormControl>
+						<FormLabel flexNoWrap textNoWrap>
+							{ __( 'Parse text from' ) }
+							<Tooltip
+								title={
+									<>
+										<strong>{ __( 'How parsing works?' ) }</strong>
+										<p>{ __( 'Text elements from specified URLs will be extracted and compared for phrase matching. Checking this box allows for parsing text strictly from headers, i.e. H1 … H5 tags, and TITLE tags. This is a useful option as copywriters often use the most important keywords in titles and headers, thus enabling the identification of keyword frequency based on headings alone.' ) }</p>
+									</>
+								}
+								placement="bottom"
+								sx={ { maxWidth: '45rem' } }
+							>
+								<Box>
+									<IconButton className="ml-s info-grey">
+										<SvgIcon name="info" />
+									</IconButton>
+								</Box>
+							</Tooltip>
+						</FormLabel>
+						<Box>
+							<MultiSelectBox
+								items={ parseHeadersValues }
+								selected={ contentGapOptions.parse_headers }
+								onChange={ ( value ) => updateOptions( { parse_headers: value } ) }
+								fitItems
+							/>
+						</Box>
+
+					</FormControl>
+					<FormControl>
+						<FormLabel flexNoWrap textNoWrap>
+							{ __( 'Word combinations' ) }
+							<Tooltip
+								title={ __( 'The "n-grams" field specifies the maximum number of words that are grouped together to form a compound keyword for search queries. For instance: 1-gram (unigram) consists of a single word (e.g., "apple"), a 2-gram (bigram) incorporates a pair of words (e.g., "fresh apple"), etc.' ) }
+								placement="bottom"
+								sx={ { maxWidth: '45rem' } }
+							>
+								<Box>
+									<IconButton className="ml-s info-grey">
+										<SvgIcon name="info" />
+									</IconButton>
+								</Box>
+							</Tooltip>
+						</FormLabel>
+						<Box>
+							<MultiSelectBox
+								items={ ngramsValues }
+								selected={ contentGapOptions.ngrams }
+								onChange={ ( value ) => updateOptions( { ngrams: value } ) }
+								fitItems
+								fitWidth
+							/>
+						</Box>
+
+					</FormControl>
+					<FormControl orientation="horizontal">
+						<MuiCheckbox
+							size="sm"
+							checked={ contentGapOptions.show_keyword_cluster }
+							onChange={ ( event ) => updateOptions( { show_keyword_cluster: event.target.checked } ) }
+							label={ __( 'Show just queries from Keyword Cluster' ) }
+							sx={ ( theme ) => ( { color: theme.palette.urlslabColors.greyDarker } ) }
+							textNoWrap
+						/>
+						<Tooltip
+							title={
+								<>
+									<strong>{ __( 'What is keyword cluster?' ) }</strong>
+									<p>{ __( 'Cluster forms keywords discovered in your database, where the same URLs rank on Google Search for each query.' ) }</p>
+									<p>{ __( 'Based on entered query we identify all other best matching keywords from the cluster.' ) }</p>
+									<p>{ __( 'If this option is selected, keywords included in page, but not found in SERP data will not be included in the table.' ) }</p>
+								</>
+							}
+							placement="bottom"
+							sx={ { maxWidth: '45rem' } }
+						>
+							<Box>
+								<IconButton className="ml-s info-grey">
+									<SvgIcon name="info" />
+								</IconButton>
+							</Box>
+						</Tooltip>
+					</FormControl>
+
+					<FormControl orientation="horizontal" >
+						<MuiCheckbox
+							size="sm"
+							checked={ contentGapOptions.compare_domains }
+							onChange={ ( event ) => updateOptions( { compare_domains: event.target.checked } ) }
+							label={ __( 'Compare domains of URLs' ) }
+							sx={ ( theme ) => ( { color: theme.palette.urlslabColors.greyDarker } ) }
+							textNoWrap
+						/>
+						<Tooltip
+							title={
+								<>
+									<strong>{ __( 'How does domain comparison work?' ) }</strong>
+									<p>{ __( 'From given URLs we extract domain name and compare from those domains all queries where given domain rank in top positions on Google. Evaluated are just processed queries, more queries your process, better results you get (e.g. 10k queries recommended). If we discover, that for given domain ranks better other URL of the domain (for specific query), we will show notification about it. This could help you to identify other URLs of domain, which rank better as select URL. This information could be helpful if you are building content clusters to identify duplicate pages with same intent or new opportunities found in competitor website. If you select this option, computation will take much longer as significantly more queries needs to be considered.' ) }</p>
+								</>
+							}
+							placement="bottom"
+							sx={ { maxWidth: '45rem' } }
+						>
+							<Box>
+								<IconButton className="ml-s info-grey">
+									<SvgIcon name="info" />
+								</IconButton>
+							</Box>
+						</Tooltip>
+					</FormControl>
+
+					{ ( contentGapOptions.show_keyword_cluster ) &&
+					<Stack direction="row" spacing={ 1 } >
+						<FormControl sx={ { marginBottom: 1 } }>
+							<FormLabel>{ __( 'Clustering level' ) }</FormLabel>
+							<Input
+								type="number"
+								defaultValue={ contentGapOptions.matching_urls }
+								onChange={ ( event ) => updateOptions( { matching_urls: event.target.value } ) }
+								// simulate our liveUpdate, until custom mui Input component isn't available
+								//onChange={ ( event ) => delay( () => setLupdateOptionsocalOptions( { matching_urls: event.target.value } ), 800 )() }
+								//onBlur={ ( event ) => event.target.value !== contentGapOptions.matching_urls ? updateOptions( { matching_urls: event.target.value } ) : null }
+								sx={ { width: 160 } }
+							/>
+						</FormControl>
+						<FormControl sx={ { marginBottom: 1 } }>
+							<FormLabel>{ __( 'Max position' ) }</FormLabel>
+							<Input
+								type="number"
+								defaultValue={ contentGapOptions.max_position }
+								onChange={ ( event ) => updateOptions( { max_position: event.target.value } ) }
+								// simulate our liveUpdate, until custom mui Input component isn't available
+								//onChange={ ( event ) => delay( () => updateOptions( { max_position: event.target.value } ), 800 )() }
+								//onBlur={ ( event ) => event.target.value !== contentGapOptions.max_position ? updateOptions( { max_position: event.target.value } ) : null }
+								sx={ { width: 160 } }
+							/>
+						</FormControl>
+					</Stack>
+					}
+				</Stack>
+			</Box>
+
+		</SettingsWrapper>
+	);
+}
+
+export default memo( GapDetailMainSettings );

--- a/admin/src/components/detailsPanel/gapDetailPanelParts/GapDetailUrlsSettings.jsx
+++ b/admin/src/components/detailsPanel/gapDetailPanelParts/GapDetailUrlsSettings.jsx
@@ -1,0 +1,222 @@
+import { memo, useCallback, useContext } from 'react';
+import { __ } from '@wordpress/i18n';
+import Button from '@mui/joy/Button';
+
+import useTablePanels from '../../../hooks/useTablePanels';
+
+import SvgIcon from '../../../elements/SvgIcon';
+import IconButton from '../../../elements/IconButton';
+
+import Box from '@mui/joy/Box';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
+import Tooltip from '@mui/joy/Tooltip';
+import MuiIconButton from '@mui/joy/IconButton';
+import CircularProgress from '@mui/joy/CircularProgress';
+
+import { ContentGapContext, maxGapUrls } from '../GapDetailPanel';
+
+function GapDetailUrlsSettings() {
+	const { loadingUrls, updateOptions } = useContext( ContentGapContext );
+	const contentGapOptions = useTablePanels( ( state ) => state.contentGapOptions );
+
+	return (
+		<Box className="limit flex">
+			{ ! loadingUrls
+				? <GapUrlsManager urls={ contentGapOptions.urls } onChange={ ( newUrls ) => updateOptions( { urls: newUrls } ) } />
+				: <Box className="limit flex flex-align-center flex-justify-center">
+					<CircularProgress />
+				</Box>
+			}
+		</Box>
+	);
+}
+
+const GapUrlsManager = memo( () => {
+	const { updateOptions } = useContext( ContentGapContext );
+	const contentGapOptions = useTablePanels( ( state ) => state.contentGapOptions );
+
+	const isMaxUrls = maxGapUrls <= Object.keys( contentGapOptions.urls ).length;
+
+	const addNewInput = useCallback( () => {
+		const newUrl = { [ `url_${ Object.keys( contentGapOptions.urls ).length }` ]: '' };
+		updateOptions( { urls: { ...contentGapOptions.urls, ...newUrl } } );
+	}, [ contentGapOptions.urls, updateOptions ] );
+
+	return (
+		<Box className="limit">
+			<Stack direction="row" flexWrap="wrap">
+
+				{ Object.keys( contentGapOptions.urls ).length > 0 &&
+					<>
+						{
+							Object.entries( contentGapOptions.urls ).map( ( [ key, url ] ) => (
+								<ColumnWrapper key={
+									// make sure to rerender inputs after change of their count, ie. after remove
+									`${ key }-${ Object.keys( contentGapOptions.urls ).length }`
+								}>
+									<UrlOption index={ key } url={ url } />
+								</ColumnWrapper>
+							) )
+						}
+					</>
+				}
+				<ColumnWrapper>
+					<Button
+						color="neutral"
+						variant="soft"
+						disabled={ isMaxUrls }
+						onClick={ addNewInput }
+						startDecorator={ ! isMaxUrls && <SvgIcon name="plus" /> }
+						sx={ ( theme ) => ( {
+							width: '100%',
+							'--Icon-fontSize': theme.vars.fontSize.sm,
+						} ) }
+					>
+						{ isMaxUrls
+							? (
+							// translators: %i is generated number, do not change it
+								__( 'Max %i URLs allowed' ).replace( '%i', maxGapUrls )
+							)
+							: __( 'Add another URL' )
+						}
+					</Button>
+				</ColumnWrapper>
+			</Stack>
+		</Box>
+	);
+} );
+
+const UrlOption = memo( ( { index, url } ) => {
+	const { updateOptions } = useContext( ContentGapContext );
+	const contentGapOptions = useTablePanels( ( state ) => state.contentGapOptions );
+
+	const { urls, processedUrls, processingUrls } = contentGapOptions;
+
+	const processedUrlData = processedUrls[ index ];
+	const isError = processedUrlData && processedUrlData.status === 'error';
+	const title = `${ __( 'URL' ) } ${ +index.replace( 'url_', '' ) + 1 }`;
+
+	const removeUrl = useCallback( ( urlKey ) => {
+		const newUrls = {};
+		const newProcessedUrls = {};
+		let customIndex = 0;
+		Object.entries( urls ).forEach( ( [ key, value ] ) => {
+			if ( urlKey !== key ) {
+				newUrls[ `url_${ customIndex }` ] = value;
+				customIndex++;
+			}
+		} );
+		customIndex = 0;
+		Object.entries( processedUrls ).forEach( ( [ key, value ] ) => {
+			if ( urlKey !== key ) {
+				newProcessedUrls[ `url_${ customIndex }` ] = value;
+				customIndex++;
+			}
+		} );
+		updateOptions( { urls: newUrls, processedUrls: newProcessedUrls } );
+	}, [ processedUrls, updateOptions, urls ] );
+
+	const updateUrl = useCallback( ( newValue, urlKey ) => {
+		const newUrls = { ...urls };
+		newUrls[ urlKey ] = newValue;
+		updateOptions( { urls: newUrls } );
+	}, [ updateOptions, urls ] );
+
+	return (
+		<FormControl
+			orientation="horizontal"
+			sx={ { justifyContent: 'flex-end' } }
+		>
+			<FormLabel
+				textNoWrap
+				sx={ { width: 65 } }
+			>{ title }</FormLabel>
+			<Tooltip
+				color={ isError ? 'danger' : 'neutral' }
+				title={
+					( processedUrlData && processedUrlData.status === 'error' )
+						? <>{ processedUrlData.message }<br />{ url }</>
+						: url
+				}
+			>
+				<Input
+					className="limit"
+					defaultValue={ url }
+					onChange={ ( event ) => updateUrl( event.target.value, index ) }
+					// simulate our liveUpdate, until custom mui Input component isn't available
+					//onChange={ ( event ) => delay( () => updateUrl( event.target.value, key ), 800 )() }
+					//onBlur={ ( event ) => event.target.value !== url ? updateUrl( event.target.value, key ) : null }
+					startDecorator={
+						<>
+							{ processingUrls &&
+								<MuiIconButton
+									size="xs"
+									variant="soft"
+									color="neutral"
+									sx={ { pointerEvents: 'none' } }
+								>
+									<CircularProgress size="sm" sx={ { '--CircularProgress-size': '17px', '--CircularProgress-thickness': '2px' } } />
+								</MuiIconButton>
+							}
+
+							{ ( ! processingUrls && processedUrlData && processedUrlData.status === 'error' ) &&
+								<MuiIconButton
+									size="xs"
+									variant="soft"
+									color="danger"
+									sx={ { pointerEvents: 'none' } }
+								>
+									<SvgIcon name="disable" />
+								</MuiIconButton>
+							}
+							{ ( ! processingUrls && processedUrlData && processedUrlData.status === 'ok' ) &&
+								<MuiIconButton
+									size="xs"
+									variant="soft"
+									color="success"
+									sx={ { pointerEvents: 'none' } }
+								>
+									<SvgIcon name="checkmark-circle" />
+								</MuiIconButton>
+							}
+						</>
+					}
+				/>
+			</Tooltip>
+			{
+				Object.keys( urls ).length > 1 &&
+					<IconButton className="ml-s info-grey-darker" onClick={ () => removeUrl( index ) }>
+						<Tooltip title={
+							// translators: %s is generated text, do not change it
+							__( 'Remove %s' ).replace( '%s', title )
+						} >
+							<Box display="flex" alignItems="center">
+								<SvgIcon name="minus-circle" />
+							</Box>
+						</Tooltip>
+					</IconButton>
+			}
+		</FormControl>
+	);
+} );
+
+const ColumnWrapper = memo( ( { children } ) => (
+	<Box sx={ ( theme ) => ( {
+		mb: 1, pr: 2,
+		width: 340,
+		[ theme.breakpoints.down( 'xxxl' ) ]: {
+			width: '50%',
+		},
+		[ theme.breakpoints.down( 'xl' ) ]: {
+			width: '33.3%',
+		},
+		[ theme.breakpoints.down( 'lg' ) ]: {
+			width: '50%',
+		},
+	} ) }>{ children }</Box>
+) );
+
+export default memo( GapDetailUrlsSettings );

--- a/admin/src/hooks/useSerpGapCompare.jsx
+++ b/admin/src/hooks/useSerpGapCompare.jsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useCallback } from 'react';
 
 export default function useSerpGapCompare( queryCol, slug = 'serp-gap' ) {
-	const setFetchOptions = useTablePanels( ( state ) => state.setFetchOptions );
+	const setContentGapOptions = useTablePanels( ( state ) => state.setContentGapOptions );
+
 	const navigate = useNavigate();
 
 	const compareUrls = useCallback( ( {
@@ -29,8 +30,7 @@ export default function useSerpGapCompare( queryCol, slug = 'serp-gap' ) {
 			return false;
 		} );
 
-		setFetchOptions( {
-			...useTablePanels.getState().fetchOptions,
+		setContentGapOptions( {
 			query,
 			urls,
 			matching_urls: 5,
@@ -48,7 +48,7 @@ export default function useSerpGapCompare( queryCol, slug = 'serp-gap' ) {
 		if ( redirect ) {
 			navigate( `/Serp/${ slug }` );
 		}
-	}, [ navigate, queryCol, setFetchOptions, slug ] );
+	}, [ navigate, queryCol, setContentGapOptions, slug ] );
 
 	return { compareUrls };
 }

--- a/admin/src/hooks/useTablePanels.jsx
+++ b/admin/src/hooks/useTablePanels.jsx
@@ -1,5 +1,23 @@
 import { create } from 'zustand';
 
+const contentGapDefaults = {
+	query: '',
+	urls: { url_0: '' },
+	matching_urls: 5,
+	max_position: 10,
+	compare_domains: false,
+	parse_headers: [ 'title', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
+	show_keyword_cluster: false,
+	country: 'us',
+	ngrams: [ 1, 2, 3, 4, 5 ],
+	// data for preprocessing
+	processedUrls: {}, // list of processed urls, is used to mark urls status
+	forceUrlsProcessing: false, // trigger processing directly as we have passed all data from outside
+	processingUrls: false, // flag to show loaders in options and table
+	allowUpdateResults: false, // flag to handle displaying of final options submit button which trigger actions for processing and table
+	willProcessing: false, // flag to decide if next submit of options require also processing of urls
+};
+
 const initialState = {
 	secondPanel: {},
 	options: [],
@@ -15,6 +33,7 @@ const useTablePanels = create( ( set ) => ( {
 	actionComplete: false,
 	imageCompare: false,
 	fetchOptions: {},
+	contentGapOptions: contentGapDefaults,
 	rowToEdit: {},
 	resetPanelsStore: () => {
 		set( initialState );
@@ -25,6 +44,7 @@ const useTablePanels = create( ( set ) => ( {
 	setRowToEdit: ( newrowToEdit ) => set( ( state ) => ( { rowToEdit: { ...state.rowToEdit, ...newrowToEdit } } ) ),
 	setPanelOverflow: ( panelOverflow ) => set( ( ) => ( { panelOverflow } ) ),
 	showSecondPanel: ( secondPanel ) => set( () => ( { secondPanel } ) ),
+	setContentGapOptions: ( values ) => set( ( state ) => ( { contentGapOptions: { ...state.contentGapOptions, ...values } } ) ),
 } ) );
 
 export default useTablePanels;

--- a/admin/src/tables/SerpContentGapTable.jsx
+++ b/admin/src/tables/SerpContentGapTable.jsx
@@ -422,15 +422,6 @@ const ContentGapCell = memo( ( { cell, index, value } ) => {
 		<Box className="content-gap-cell" sx={ { ...cellStyles } }>
 
 			<div className="content-gap-cell-grid">
-				{ position === -1 &&
-					<div className="content-gap-cell-grid-value">
-						<Tooltip title={ __( 'Comparing max 5 domains.' ) }>
-							<IconButton size="xs" color="neutral">
-								<SvgIcon name="info" />
-							</IconButton>
-						</Tooltip>
-					</div>
-				}
 
 				{ /* keep always visible .content-gap-cell-grid-value to keep value alignment in own column */ }
 				<div
@@ -448,6 +439,17 @@ const ContentGapCell = memo( ( { cell, index, value } ) => {
 						{ isPosition && `${ position }.` }
 					</div>
 				</Tooltip>
+
+				{ /* keep always visible .content-gap-cell-grid-value to keep value alignment in own column */ }
+				{ position === -1 &&
+				<div className="content-gap-cell-grid-value">
+					<Tooltip title={ __( 'Comparing max 5 domains.' ) }>
+						<IconButton size="xs" color="neutral">
+							<SvgIcon name="info" />
+						</IconButton>
+					</Tooltip>
+				</div>
+				}
 			</div>
 
 			{ url_name && url_name !== value &&

--- a/admin/src/tables/SerpContentGapTable.jsx
+++ b/admin/src/tables/SerpContentGapTable.jsx
@@ -18,6 +18,7 @@ import useTableStore from '../hooks/useTableStore';
 import useTablePanels from '../hooks/useTablePanels';
 import useChangeRow from '../hooks/useChangeRow';
 import useSerpGapCompare from '../hooks/useSerpGapCompare';
+import useSelectRows from '../hooks/useSelectRows';
 import { countriesList, countriesListForSelect } from '../api/fetchCountries';
 
 import { getTooltipUrlsList } from '../lib/elementsHelpers';
@@ -32,7 +33,6 @@ import DescriptionBox from '../elements/DescriptionBox';
 import GapDetailPanel from '../components/detailsPanel/GapDetailPanel';
 
 import '../assets/styles/layouts/ContentGapTableCells.scss';
-import useSelectRows from '../hooks/useSelectRows';
 
 const paginationId = 'query_id';
 const optionalSelector = '';

--- a/admin/src/tables/SerpContentGapTable.jsx
+++ b/admin/src/tables/SerpContentGapTable.jsx
@@ -390,11 +390,7 @@ const TableContent = memo( ( { slug } ) => {
 const ContentGapCell = memo( ( { cell, index, value } ) => {
 	const url_name = cell?.row?.original[ `url_name_${ index }` ];
 	const position = cell?.getValue();
-
-	// value with x, ie x5
 	const isWords = ( url_name === null || url_name === value ) && cell?.row?.original[ `words_${ index }` ] > 0;
-
-	// value with hash, ie #5
 	const isPosition = typeof position === 'number' && position > 0;
 
 	const cellStyles = colorRankingInnerStyles( {
@@ -415,6 +411,8 @@ const ContentGapCell = memo( ( { cell, index, value } ) => {
 						</Tooltip>
 					</div>
 				}
+
+				{ /* keep always visible .content-gap-cell-grid-value to keep value alignment in own column */ }
 				<div
 					className="content-gap-cell-grid-value content-gap-cell-grid-value-words">
 					{ isWords &&
@@ -423,13 +421,13 @@ const ContentGapCell = memo( ( { cell, index, value } ) => {
 						</Tooltip>
 					}
 				</div>
-				{ isPosition &&
-					<Tooltip title={ __( 'Position in search results: ' ) + position }>
-						<div className="content-gap-cell-grid-value content-gap-cell-grid-value-position">
-							{ `${ position }.` }
-						</div>
-					</Tooltip>
-				}
+
+				{ /* keep always visible .content-gap-cell-grid-value to keep value alignment in own column */ }
+				<Tooltip title={ isPosition ? __( 'Position in search results: ' ) + position : null }>
+					<div className="content-gap-cell-grid-value content-gap-cell-grid-value-position">
+						{ isPosition && `${ position }.` }
+					</div>
+				</Tooltip>
 			</div>
 
 			{ url_name && url_name !== value &&


### PR DESCRIPTION
**Changes proposed in this Pull Request**
-- changes in Compare Gap options are thrown only after submission using `Update Results` button to avoid sending api requests after every change of some option.
-- options extracted to custom state to avoid changing of `fetchOptions` state that triggers tables rerender, `fetchOptions` updated after click on submit button.
-- Content Gap page loaded from another page (ie. Queries table after click on Content Gap button) runs requests immediately as data are prefilled to show wanted table
-- options in Content Gap recognize which option was changes - so if is needed to run preprocess of urls first and then update table, or if option which is not used by `prepare` query was changed, then only table is updated without `prepare` request.

Maybe improve in future: after change of options check exactly previous data with current changed data, right now button `Update Results` appear immediately after some change, even user revert option to previous state that is currently presented in table...

Close QualityUnit/web-issues#2333
Close QualityUnit/web-issues#2335
Close QualityUnit/web-issues#2365
