### PR TITLE
[1773] feat: disabled widgets if modules are not active

### DIFF
--- a/blocks/.eslintrc
+++ b/blocks/.eslintrc
@@ -2,7 +2,8 @@
 	"root": true,
 	"env": {
 		"worker": true,
-		"es6": true
+		"es6": true,
+		"browser": true
 	},
 	"globals": {
 		"ResizeObserver": false,

--- a/blocks/src/api.js
+++ b/blocks/src/api.js
@@ -29,3 +29,48 @@ export const fetchModuleOptions = async ( {
 		return null;
 	}
 };
+
+export async function getFetch( slug ) {
+	try {
+		const result = await fetch( wpApiSettings.root + `urlslab/v1${ slug ? `/${ slug }` : '' }`, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				accept: 'application/json',
+				'X-WP-Nonce': window.wpApiSettings.nonce,
+			},
+			credentials: 'include',
+		} );
+
+		return result;
+	} catch ( error ) {
+		return false;
+	}
+}
+
+export const fetchModules = async () => {
+	const response = await getFetch( 'module' ).then( ( data ) => data );
+	if ( response.ok ) {
+		return response.json();
+	}
+	return response;
+};
+
+export async function setModule( slug, object ) {
+	try {
+		const result = await fetch( wpApiSettings.root + `urlslab/v1/module/${ slug }`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				accept: 'application/json',
+				'X-WP-Nonce': window.wpApiSettings.nonce,
+			},
+			credentials: 'include',
+			body: JSON.stringify( object ),
+		} );
+
+		return result;
+	} catch ( error ) {
+		return false;
+	}
+}

--- a/blocks/src/blocks/related-articles/block.json
+++ b/blocks/src/blocks/related-articles/block.json
@@ -30,6 +30,9 @@
 		"defaultImage": {
 			"type": "string",
 			"default": ""
+		},
+		"active": {
+			"type": "boolean"
 		}
 	},
 	"editorScript": "urlslab-related-articles-block",

--- a/blocks/src/blocks/related-articles/edit.js
+++ b/blocks/src/blocks/related-articles/edit.js
@@ -1,16 +1,20 @@
+/* eslint-disable no-nested-ternary */
 /*global _urlslab_related_articles_block_vars*/
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { Icon, pages } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl, SelectControl } from '@wordpress/components';
+import { PanelBody, TextControl, ToggleControl, SelectControl, Button, Spinner } from '@wordpress/components';
+
+import useModules from '../../hooks/useModules';
 
 import MediaUpload from '../../components/MediaUpload';
 
 const slug = 'related-articles';
+const moduleSlug = 'urlslab-related-resources';
 
 const Edit = ( { attributes, setAttributes } ) => {
 	const defaultUrl = useSelect( ( select ) => select( 'core/editor' ).getPermalink(), [] );
@@ -18,61 +22,65 @@ const Edit = ( { attributes, setAttributes } ) => {
 	const inputId = `urlslab-${ slug }-input-${ instanceId }`;
 	const generalDefaultImageRef = useRef( _urlslab_related_articles_block_vars ? _urlslab_related_articles_block_vars.generalDefaultImage : null );
 	const usedGeneralDefaultImage = attributes.defaultImage === '' && generalDefaultImageRef.current;
+	const [ reload, setReload ] = useState();
+	const { modulesStatus, activateModule } = useModules( reload );
 
 	return (
 		<>
-			<InspectorControls key="setting">
-				<PanelBody
-					title={ __( 'Options', 'urlslab' ) }
-					initialOpen={ true }
-				>
-					<TextControl
-						label={ __( 'Articles count', 'urlslab' ) }
-						help={ __( 'Number of displayed related articles.', 'urlslab' ) }
-						type="number"
-						min={ 0 }
-						value={ attributes.relatedCount }
-						onChange={ ( val ) => setAttributes( { relatedCount: val } ) }
-					/>
-
-					<ToggleControl
-						label={ __( 'Show summary', 'urlslab' ) }
-						checked={ attributes.showSummary }
-						onChange={ ( val ) => setAttributes( { showSummary: val } ) }
-					/>
-
-					<ToggleControl
-						label={ __( 'Show image', 'urlslab' ) }
-						checked={ attributes.showImage }
-						onChange={ ( val ) => setAttributes( { showImage: val } ) }
-					/>
-
-					{ attributes.showImage &&
-					<>
-						<SelectControl
-							label={ __( 'Image size', 'urlslab' ) }
-							value={ attributes.imageSize }
-							options={ [
-								{ label: __( 'Carousel thumbnail', 'urlslab' ), value: 'carousel-thumbnail' },
-								{ label: __( 'Full page thumbnail', 'urlslab' ), value: 'full-page-thumbnail' },
-								{ label: __( 'Carousel', 'urlslab' ), value: 'carousel' },
-								{ label: __( 'Full page', 'urlslab' ), value: 'full-page' },
-							] }
-							onChange={ ( val ) => setAttributes( { imageSize: val } ) }
+			{ modulesStatus && modulesStatus[ moduleSlug ]?.active &&
+				<InspectorControls key="setting">
+					<PanelBody
+						title={ __( 'Options', 'urlslab' ) }
+						initialOpen={ true }
+					>
+						<TextControl
+							label={ __( 'Articles count', 'urlslab' ) }
+							help={ __( 'Number of displayed related articles.', 'urlslab' ) }
+							type="number"
+							min={ 0 }
+							value={ attributes.relatedCount }
+							onChange={ ( val ) => setAttributes( { relatedCount: val } ) }
 						/>
 
-						<MediaUpload
-							label={ __( 'Default image', 'urlslab' ) }
-							help={ usedGeneralDefaultImage ? __( 'Applied is default image from URLsLab Related Articles settings.', 'urlslab' ) : null }
-							url={ attributes.defaultImage !== '' ? attributes.defaultImage : generalDefaultImageRef.current }
-							actionCallback={ ( val ) => setAttributes( { defaultImage: val } ) }
-							showRemoveButton={ ! usedGeneralDefaultImage }
+						<ToggleControl
+							label={ __( 'Show summary', 'urlslab' ) }
+							checked={ attributes.showSummary }
+							onChange={ ( val ) => setAttributes( { showSummary: val } ) }
 						/>
-					</>
-					}
 
-				</PanelBody>
-			</InspectorControls>
+						<ToggleControl
+							label={ __( 'Show image', 'urlslab' ) }
+							checked={ attributes.showImage }
+							onChange={ ( val ) => setAttributes( { showImage: val } ) }
+						/>
+
+						{ attributes.showImage &&
+						<>
+							<SelectControl
+								label={ __( 'Image size', 'urlslab' ) }
+								value={ attributes.imageSize }
+								options={ [
+									{ label: __( 'Carousel thumbnail', 'urlslab' ), value: 'carousel-thumbnail' },
+									{ label: __( 'Full page thumbnail', 'urlslab' ), value: 'full-page-thumbnail' },
+									{ label: __( 'Carousel', 'urlslab' ), value: 'carousel' },
+									{ label: __( 'Full page', 'urlslab' ), value: 'full-page' },
+								] }
+								onChange={ ( val ) => setAttributes( { imageSize: val } ) }
+							/>
+
+							<MediaUpload
+								label={ __( 'Default image', 'urlslab' ) }
+								help={ usedGeneralDefaultImage ? __( 'Applied is default image from URLsLab Related Articles settings.', 'urlslab' ) : null }
+								url={ attributes.defaultImage !== '' ? attributes.defaultImage : generalDefaultImageRef.current }
+								actionCallback={ ( val ) => setAttributes( { defaultImage: val } ) }
+								showRemoveButton={ ! usedGeneralDefaultImage }
+							/>
+						</>
+						}
+
+					</PanelBody>
+				</InspectorControls>
+			}
 
 			<div {
 				...useBlockProps(
@@ -89,15 +97,26 @@ const Edit = ( { attributes, setAttributes } ) => {
 				</label>
 
 				<div className="urlslab-fullwidth-wrapper">
-					<TextControl
-						id={ inputId }
-						label={ __( 'Show articles related to url', 'urlslab' ) }
-						help={ __( 'Leave empty to use current page url, or type any other internal or external url.', 'urlslab' ) }
-						type="url"
-						value={ attributes.url }
-						placeholder={ defaultUrl }
-						onChange={ ( val ) => setAttributes( { url: val } ) }
-					/>
+					{ modulesStatus && modulesStatus[ 'urlslab-related-resources' ]?.active
+						? <TextControl
+							id={ inputId }
+							label={ __( 'Show articles related to url', 'urlslab' ) }
+							help={ __( 'Leave empty to use current page url, or type any other internal or external url.', 'urlslab' ) }
+							type="url"
+							value={ attributes.url }
+							placeholder={ defaultUrl }
+							onChange={ ( val ) => setAttributes( { url: val } ) }
+						/>
+						: modulesStatus
+							? <>
+								<p>{ __( 'Related Articles module in URLsLab is not activated. If you want to use this widget, activate it please.' ) }</p>
+								<Button variant="primary"
+									text={ __( 'Activate Related Articles module' ) }
+									onClick={ ( res ) => activateModule( moduleSlug, setReload( res ) ) }
+								/>
+							</>
+							: <Spinner />
+					}
 				</div>
 			</div>
 		</>

--- a/blocks/src/blocks/screenshot/block.json
+++ b/blocks/src/blocks/screenshot/block.json
@@ -30,6 +30,9 @@
 		"defaultImage": {
 			"type": "string",
 			"default": ""
+		},
+		"active": {
+			"type": "boolean"
 		}
 	},
 	"editorScript": "urlslab-screenshot-block",

--- a/blocks/src/blocks/screenshot/edit.js
+++ b/blocks/src/blocks/screenshot/edit.js
@@ -1,20 +1,27 @@
+/* eslint-disable no-nested-ternary */
+import { useState } from 'react';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Icon, image } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, SelectControl } from '@wordpress/components';
+import { PanelBody, TextControl, SelectControl, Button, Spinner } from '@wordpress/components';
 
 import MediaUpload from '../../components/MediaUpload';
+import useModules from '../../hooks/useModules';
 
 const slug = 'screenshot';
+const moduleSlug = 'urlslab-urls';
 
 const Edit = ( { attributes, setAttributes } ) => {
 	const instanceId = useInstanceId( Edit );
 	const inputId = `urlslab-${ slug }-input-${ instanceId }`;
+	const [ reload, setReload ] = useState();
+	const { modulesStatus, activateModule } = useModules( reload );
 
 	return (
 		<>
+			{ modulesStatus && modulesStatus[ moduleSlug ]?.active &&
 			<InspectorControls key="setting">
 				<PanelBody
 					title={ __( 'Options', 'urlslab' ) }
@@ -62,6 +69,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 
 				</PanelBody>
 			</InspectorControls>
+			}
 
 			<div {
 				...useBlockProps(
@@ -78,16 +86,27 @@ const Edit = ( { attributes, setAttributes } ) => {
 				</label>
 
 				<div className="urlslab-fullwidth-wrapper">
-					<TextControl
-						id={ inputId }
-						label={ __( 'Page url', 'urlslab' ) }
-						help={ __( 'Link to the page from which a screenshot should be taken.', 'urlslab' ) }
-						type="url"
-						value={ attributes.url }
-						placeholder={ __( 'Insert website url', 'urlslab' ) }
-						onChange={ ( val ) => setAttributes( { url: val } ) }
-						required
-					/>
+					{ modulesStatus && modulesStatus[ 'urlslab-urls' ]?.active
+						? <TextControl
+							id={ inputId }
+							label={ __( 'Page url', 'urlslab' ) }
+							help={ __( 'Link to the page from which a screenshot should be taken.', 'urlslab' ) }
+							type="url"
+							value={ attributes.url }
+							placeholder={ __( 'Insert website url', 'urlslab' ) }
+							onChange={ ( val ) => setAttributes( { url: val } ) }
+							required
+						/>
+						: modulesStatus
+							? <>
+								<p>{ __( 'This widget requires Link Building module in URLsLab to be active. If you want to use this widget, activate Link Building module please.' ) }</p>
+								<Button variant="primary"
+									text={ __( 'Activate Link Building module' ) }
+									onClick={ ( res ) => activateModule( moduleSlug, setReload( res ) ) }
+								/>
+							</>
+							: <Spinner />
+					}
 				</div>
 			</div>
 		</>

--- a/blocks/src/hooks/useModules.jsx
+++ b/blocks/src/hooks/useModules.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { fetchModules, setModule } from '../api';
+
+export default function useModules( reload ) {
+	const modulesStorage = sessionStorage.getItem( 'modules' );
+	const [ modulesStatus, setModulesStatus ] = useState( modulesStorage || {} );
+
+	const activateModule = ( slug, result ) => {
+		setModule( slug, { active: true } ).then(
+			( response ) => {
+				if ( response.ok ) {
+					let modules = JSON.parse( modulesStorage );
+					modules = { ...modules, [ slug ]: { ...modules[ slug ], active: true } };
+					sessionStorage.setItem( 'modules', JSON.stringify( modules ) );
+					setModulesStatus( modules );
+					result( true );
+					return true;
+				}
+			}
+		);
+	};
+
+	useEffect( () => {
+		if ( ! modulesStorage ) {
+			fetchModules().then( ( mods ) => {
+				sessionStorage.setItem( 'modules', JSON.stringify( mods ) );
+				setModulesStatus( mods );
+			} );
+		}
+	}, [ ] );
+
+	if ( reload ) {
+		return { modulesStatus, activateModule };
+	}
+
+	if ( Object.keys( modulesStatus )?.length ) {
+		return { modulesStatus, activateModule };
+	}
+
+	return {
+		modulesStatus: JSON.parse( modulesStorage ),
+		activateModule,
+	};
+}

--- a/includes/api/class-urlslab-api-process.php
+++ b/includes/api/class-urlslab-api-process.php
@@ -122,6 +122,7 @@ class Urlslab_Api_Process extends Urlslab_Api_Table {
 			array(
 				'methods' => WP_REST_Server::READABLE,
 				'callback' => array( $this, 'get_process_result' ),
+				'permission_callback' => '__return_true',
 				'args' => array(
 					'process_id' => array(
 						'required' => true,

--- a/includes/api/class-urlslab-api-urls.php
+++ b/includes/api/class-urlslab-api-urls.php
@@ -250,6 +250,7 @@ class Urlslab_Api_Urls extends Urlslab_Api_Table {
 			array(
 				'methods'  => WP_REST_Server::CREATABLE,
 				'callback' => array( $this, 'get_url_changes' ),
+				'permission_callback' => '__return_true',
 				'args'     => array_merge(
 					$this->get_table_arguments(),
 					array(


### PR DESCRIPTION
**Changes proposed in this Pull Request**
disabled related articles and screenshot widgets if modules are not active

**Testing instructions**
Disabled Related Articles or URLs module. Go to post and add the Screenshot or Related Articles widget.
It should say module is disabled and show only Activate module button. After click on button, module should be activated (check fetch request) and module settings in sidebar and input field should become visibe

Close QualityUnit/web-issues#1773
