### PR TITLE
[2509] fix: paste in tinymce editor, eslint fix

### DIFF
--- a/admin/.eslintrc
+++ b/admin/.eslintrc
@@ -24,6 +24,7 @@
 		"import/no-extraneous-dependencies": 0,
 		"react/jsx-indent-props": 0,
 		"react/no-unescaped-entities": 0,
+		"jsdoc/newline-after-description": 0,
 		"no-bitwise":["error", { "allow": ["~"] }]
 	},
 	"settings": {

--- a/admin/src/elements/Editor.jsx
+++ b/admin/src/elements/Editor.jsx
@@ -88,7 +88,7 @@ export default function Editor( { defaultValue, className, style, label, descrip
 					menubar: false,
 					entity_encoding: 'raw',
 					plugins: [
-						'advlist', 'autolink', 'lists', 'link', 'image', 'anchor', 'media', 'table', 'code',
+						'advlist', 'anchor', 'autolink', 'code', 'lists', 'link', 'image', 'media', 'paste', 'table',
 					],
 					toolbar: [ 'blocks | bold italic forecolor | alignleft aligncenter',
 						'alignright alignjustify | bullist numlist outdent indent | code help' ],


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Allowed pasting in TinyMCE editor

Close QualityUnit/web-issues#2509
