### PR TITLE
feat: onboarding search query options as textarea

### DIFF
--- a/admin/src/onboarding/steps/StepApiKey.jsx
+++ b/admin/src/onboarding/steps/StepApiKey.jsx
@@ -41,7 +41,7 @@ const StepApiKey = ( { apiSetting } ) => {
 			setApiKey( userApiKey );
 			setNextStep();
 		} else {
-			handleApiError( 'onboarding-apikey-step', { title: __( 'API key saving failed' ) } );
+			handleApiError( 'onboarding-apikey-step', response, { title: __( 'API key saving failed' ) } );
 		}
 
 		setUpdating( false );

--- a/admin/src/onboarding/steps/StepModules.jsx
+++ b/admin/src/onboarding/steps/StepModules.jsx
@@ -50,13 +50,11 @@ const StepModules = () => {
 		// paid plan, set schedule and finish onboarding process
 		if ( userData.scheduleData.urls?.length ) {
 			const response = await postFetch( `schedule/create`, userData.scheduleData, { skipErrorHandling: true } );
-			if ( response.ok ) {
-				await setFinishedOnboarding( queryClient );
-				successNotify();
+			if ( ! response.ok ) {
+				handleApiError( 'onboarding-modules-step', { title: __( 'Data saving failed' ) } );
+				setUpdating( false );
 				return false;
 			}
-			handleApiError( 'onboarding-modules-step', { title: __( 'Data saving failed' ) } );
-			return false;
 		}
 
 		//activate selected modules


### PR DESCRIPTION
**Changes proposed in this Pull Request**
-- onboarding Search query input changed to textarea for multiple queries
-- fixed empty response from `serp-queries/create` api

-- additional keywords selection is still disabled in `Choose search query` step per request in pr https://github.com/QualityUnit/wp-urlslab/pull/1492

Close QualityUnit/web-issues#2550
