### PR TITLE
Web vitals charts changes & bugfixes

### DIFF
--- a/admin/src/app/mui_joy/theme.js
+++ b/admin/src/app/mui_joy/theme.js
@@ -284,4 +284,3 @@ export const urlslabTheme = extendTheme( {
 
 	},
 } );
-

--- a/admin/src/app/mui_joy/themes/tooltipTheme.js
+++ b/admin/src/app/mui_joy/themes/tooltipTheme.js
@@ -14,7 +14,13 @@ const tooltipTheme = {
 					color: theme.vars.palette.common.white,
 					padding: '.5em',
 				},
-
+				...( ownerState.countryMapTooltip ) && {
+					padding: theme.spacing( 1.5 ),
+					color: theme.vars.palette.text.secondary,
+					background: theme.vars.palette.common.white,
+					boxShadow: theme.vars.shadow.md,
+					minWidth: '8rem',
+				},
 				a: {
 					'&.MuiBox-root[class]': {
 						color: 'var(--urlslab-palette-white) !important',

--- a/admin/src/assets/styles/components/_FloatingPanel.scss
+++ b/admin/src/assets/styles/components/_FloatingPanel.scss
@@ -38,6 +38,7 @@
 	}
 
 	&.urslab-TableFilter-panel {
+		z-index: 4; // override z-index of module view header bottom that possibly covers popups
 
 		.urlslab-SortMenu {
 			min-width: 13em;

--- a/admin/src/assets/styles/components/_ModuleViewHeader.scss
+++ b/admin/src/assets/styles/components/_ModuleViewHeader.scss
@@ -42,10 +42,6 @@
 			border-bottom: 1px solid $grey-light;
 		}
 
-		.refresh-icon.refreshing svg {
-			animation: 0.75s rotate linear infinite;
-		}
-
 		.urlslab-SortMenu {
 			min-width: 13em;
 			max-width: none;

--- a/admin/src/assets/styles/components/datepicker/datepicker.scss
+++ b/admin/src/assets/styles/components/datepicker/datepicker.scss
@@ -337,7 +337,6 @@ value-keyword-case */
 				box-sizing: content-box;
 
 				li.react-datepicker__time-list-item {
-					height: 30px;
 					padding: 5px 10px;
 					white-space: nowrap;
 
@@ -353,7 +352,7 @@ value-keyword-case */
 
 						&:hover {
 							background-color: $datepicker__selected-color;
-							color: $datepicker__selected-color;
+							color: $white;
 						}
 					}
 

--- a/admin/src/assets/styles/elements/_IconButton.scss
+++ b/admin/src/assets/styles/elements/_IconButton.scss
@@ -82,4 +82,8 @@
 			fill: $primary-color;
 		}
 	}
+
+	&.refresh-icon.refreshing svg {
+		animation: 0.75s rotate linear infinite;
+	}
 }

--- a/admin/src/components/TableFilterPanel.jsx
+++ b/admin/src/components/TableFilterPanel.jsx
@@ -136,6 +136,26 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 		};
 	}, [ onEdit ] );
 
+	// handle date by effect that allow us to set current filter state also on datepicker mount with default value, no only on datepicker change event.
+	useEffect( () => {
+		if ( state.filterObj.keyType === 'date' && notBetween ) {
+			const { correctedDate } = dateWithTimezone( date );
+			dispatch( { type: 'setFilterVal', val: correctedDate.replace( /^(.+?)T(.+?)\..+$/g, '$1 $2' ) } );
+		}
+	}, [ date, dispatch, notBetween, state.filterObj.keyType ] );
+
+	useEffect( () => {
+		if ( state.filterObj.keyType === 'date' && ! notBetween ) {
+			dispatch( {
+				type: 'setFilterVal',
+				val: {
+					min: dateWithTimezone( startDate ).correctedDate.replace( /^(.+?)T(.+?)\..+$/g, '$1 $2' ),
+					max: dateWithTimezone( endDate ).correctedDate.replace( /^(.+?)T(.+?)\..+$/g, '$1 $2' ),
+				},
+			} );
+		}
+	}, [ startDate, endDate, dispatch, notBetween, state.filterObj.keyType ] );
+
 	return (
 		<div ref={ ref } className={ `urlslab-panel fadeInto urslab-floating-panel urslab-TableFilter-panel` }>
 			<div className="urlslab-panel-header urslab-TableFilter-panel-header pb-m">
@@ -246,9 +266,8 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 							showTimeSelect
 							shouldCloseOnSelect={ false }
 							onChange={ ( val ) => {
-								const { origDate, correctedDate } = dateWithTimezone( val );
+								const { origDate } = dateWithTimezone( val );
 								setDate( origDate );
-								dispatch( { type: 'setFilterVal', val: correctedDate.replace( /^(.+?)T(.+?)\..+$/g, '$1 $2' ) } );
 							} }
 						/>
 					</div>
@@ -270,9 +289,8 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 								endDate={ endDate }
 								maxDate={ endDate }
 								onChange={ ( val ) => {
-									const { origDate, correctedDate } = dateWithTimezone( val );
+									const { origDate } = dateWithTimezone( val );
 									setStartDate( origDate );
-									dispatch( { type: 'setFilterVal', val: { ...state.filterObj.filterVal, min: correctedDate.replace( /^(.+?)T(.+?)\..+$/g, '$1 $2' ) } } );
 								} }
 							/>
 						</div>
@@ -291,9 +309,8 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 								endDate={ endDate }
 								minDate={ startDate }
 								onChange={ ( val ) => {
-									const { origDate, correctedDate } = dateWithTimezone( val );
+									const { origDate } = dateWithTimezone( val );
 									setEndDate( origDate );
-									dispatch( { type: 'setFilterVal', val: { ...state.filterObj.filterVal, max: correctedDate.replace( /^(.+?)T(.+?)\..+$/g, '$1 $2' ) } } );
 								} }
 							/>
 						</div>

--- a/admin/src/components/TableFilterPanel.jsx
+++ b/admin/src/components/TableFilterPanel.jsx
@@ -110,16 +110,30 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 	}, [ header, state.filterObj.keyType ] );
 
 	useEffect( () => {
-		window.addEventListener( 'keydown', ( event ) => {
+		const outsideClick = ( event ) => {
 			if ( event.key === 'Escape' ) {
 				onEdit( false );
+				return;
 			}
-		} );
-		window.addEventListener( 'click', ( event ) => {
-			if ( ! ref.current?.contains( event.target ) && ! event.target.closest( '.FilterButton' ) && ! event.target.closest( '.MuiAutocomplete-listbox' ) ) {
+
+			if (
+				! ref.current?.contains( event.target ) &&
+				! event.target.closest( '.FilterButton' ) &&
+				! event.target.closest( '.MuiAutocomplete-listbox' ) &&
+				// check for datepicker day node which is removed from dom after click.
+				// immediately after selection of day which is outside displayed month, component changes to month of clicked day and received event node doesn't exists anymore as child of current ref, so filter panel is closed
+				! ( event.target.classList.contains( 'react-datepicker__day--outside-month' ) && ! event.target.parentNode )
+			) {
 				onEdit( false );
 			}
-		} );
+		};
+		window.addEventListener( 'keydown', outsideClick );
+		window.addEventListener( 'click', outsideClick );
+
+		return () => {
+			window.removeEventListener( 'keydown', outsideClick );
+			window.removeEventListener( 'click', outsideClick );
+		};
 	}, [ onEdit ] );
 
 	return (

--- a/admin/src/components/TableFilterPanel.jsx
+++ b/admin/src/components/TableFilterPanel.jsx
@@ -70,12 +70,12 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 	useEffect( () => {
 		if ( state.filterObj.keyType === 'string' ) {
 			dispatch( { type: 'setFilterOp', op: filters[ key ]?.op || 'LIKE' } );
-			dispatch( { type: 'setFilterVal', val: filters[ key ]?.val } );
+			dispatch( { type: 'setFilterVal', val: filters[ key ]?.val !== undefined ? filters[ key ]?.val : '' } );
 		}
 
 		if ( state.filterObj.keyType === 'browser' ) {
 			dispatch( { type: 'setFilterOp', op: filters[ key ]?.op || 'LIKE' } );
-			dispatch( { type: 'setFilterVal', val: filters[ key ]?.val } );
+			dispatch( { type: 'setFilterVal', val: filters[ key ]?.val !== undefined ? filters[ key ]?.val : { browser: [ '' ], system: '' } } );
 		}
 
 		if ( state.filterObj.keyType === 'date' ) {
@@ -85,7 +85,7 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 
 		if ( state.filterObj.keyType === 'number' ) {
 			dispatch( { type: 'setFilterOp', op: filters[ key ]?.op || '=' } );
-			dispatch( { type: 'setFilterVal', val: filters[ key ]?.val } );
+			dispatch( { type: 'setFilterVal', val: filters[ key ]?.val !== undefined ? filters[ key ]?.val : 0 } );
 		}
 		if ( state.filterObj.keyType === 'menu' ) {
 			dispatch( { type: 'setFilterOp', op: filters[ key ]?.op || '=' } );
@@ -327,7 +327,7 @@ function TableFilterPanel( { props, onEdit, customSlug, customData } ) {
 
 			<div className="Buttons mt-m flex flex-align-center">
 				<Button variant="plain" color="neutral" onClick={ () => handleOnEdit( false ) } sx={ { ml: 'auto', mr: 1 } }>{ __( 'Cancel' ) }</Button>
-				<Button onClick={ () => handleOnEdit( state.filterObj ) }>{ __( 'Save' ) }</Button>
+				<Button onClick={ () => handleOnEdit( state.filterObj ) } disabled={ state.filterObj.filterVal === undefined } >{ __( 'Save' ) }</Button>
 			</div>
 		</div>
 	);

--- a/admin/src/components/TablePanel.jsx
+++ b/admin/src/components/TablePanel.jsx
@@ -5,7 +5,7 @@ import Stack from '@mui/joy/Stack';
 import Divider from '@mui/joy/Divider';
 
 // simple panel used to switching between table screen and another screen with another data, ie. screen with charts
-const TablePanel = ( { children, actionButton, title, subtitle, noContentPadding } ) => {
+const TablePanel = ( { children, actionButtons, title, subtitle, noContentPadding } ) => {
 	return (
 		<Box
 			className="urlslab-TablePanel"
@@ -22,7 +22,7 @@ const TablePanel = ( { children, actionButton, title, subtitle, noContentPadding
 					borderBottom: `1px solid ${ theme.vars.palette.divider }`,
 				} ) }>
 				<Stack direction="row" alignItems="center" spacing={ 2 }>
-					{ actionButton && actionButton }
+					{ actionButtons && actionButtons }
 
 					{ title &&
 					<>

--- a/admin/src/components/charts/AreaChart.jsx
+++ b/admin/src/components/charts/AreaChart.jsx
@@ -17,6 +17,7 @@ import { setChartDataColors } from '../../lib/chartsHelpers';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import ButtonGroup from '@mui/joy/ButtonGroup';
+import AbsoluteCoverBox from '../../elements/AbsoluteCoverBox';
 
 /**
  *
@@ -61,21 +62,23 @@ import ButtonGroup from '@mui/joy/ButtonGroup';
  * @param {Object}        props.chartsMapper       - object containing optionKeys from chart data and text that represent chart in popup
  * @param {Object}        props.legendTitlesMapper - not required object with shortened options labels used in legend, if not provided, used are labels from chartsMapper
  * @param {Object}        props.colorsMapper       - mapper used to define color for specific option displayed in country popup
+ * @param {boolean}       props.isReloading        - flag to cover chart with loader while reloading data
  */
-const AreaChart = ( { data, height, xAxisKey, chartsMapper, colorsMapper, legendTitlesMapper } ) => {
+const AreaChart = ( { data, height, xAxisKey, chartsMapper, colorsMapper, legendTitlesMapper, isReloading } ) => {
 	const [ hiddenCharts, setHiddenCharts ] = useState( {} );
 	// if charts colors are not provided, loop default colors and set them to chart lines
 	const chartsColors = colorsMapper ? { ...colorsMapper } : setChartDataColors( chartsMapper );
 
 	return (
-		<Box>
+		<Box position="relative">
 			<Box
 				sx={ ( theme ) => ( {
 					height: 0,
 					position: 'relative',
 					paddingBottom: `${ height }px`,
-
 					fontSize: theme.vars.fontSize.sm,
+					...( isReloading ? { opacity: 0.3 } : null ),
+
 					'.recharts-responsive-container': {
 						position: 'absolute',
 						top: 0,
@@ -136,6 +139,7 @@ const AreaChart = ( { data, height, xAxisKey, chartsMapper, colorsMapper, legend
 					</RechartsAreaChart>
 				</ResponsiveContainer>
 			</Box>
+			{ isReloading && <AbsoluteCoverBox /> }
 		</Box>
 	);
 };

--- a/admin/src/components/charts/AreaChart.jsx
+++ b/admin/src/components/charts/AreaChart.jsx
@@ -99,19 +99,17 @@ const AreaChart = ( { data, height, xAxisKey, chartsMapper, colorsMapper, legend
 							}
 						</defs>
 						<CartesianGrid vertical={ false } />
-						<XAxis
-							dataKey={ xAxisKey }
-							includeHidden
-						/>
+						<XAxis dataKey={ xAxisKey } />
 						<YAxis
-							domain={ [ 0, 'dataMax' ] }
-							includeHidden
+							width={ 75 }
+							domain={ [ 'dataMin', 'dataMax' ] }
 						/>
 						<RechartsTooltip content={ <ChartTooltipContent /> } />
 						<Legend
 							content={ <CustomLegend buttonsData={ { chartsMapper, chartsColors, legendTitlesMapper, hiddenCharts, setHiddenCharts } } /> }
 							align="left"
 							verticalAlign="top"
+							//height={ 30 }
 						/>
 						{
 							Object.entries( chartsMapper ).map( ( [ key, name ] ) => {
@@ -156,7 +154,7 @@ const CustomLegend = memo( ( props ) => {
 	return (
 		<>
 			<ButtonGroup
-				sx={ { mb: 2 } }
+				sx={ { mb: 3 } }
 			>
 				{ Object.entries( chartsMapper ).map( ( [ key, value ] ) => {
 					return (

--- a/admin/src/elements/AbsoluteCoverBox.jsx
+++ b/admin/src/elements/AbsoluteCoverBox.jsx
@@ -1,0 +1,25 @@
+import { memo } from 'react';
+import Box from '@mui/joy/Box';
+import CircularProgress from '@mui/joy/CircularProgress';
+
+const AbsoluteCoverBox = ( { children } ) => {
+	return (
+		<Box
+			sx={ {
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				width: '100%',
+				height: '100%',
+				zIndex: 1,
+			} }
+		>
+			{ children || <CircularProgress /> }
+		</Box>
+	);
+};
+
+export default memo( AbsoluteCoverBox );

--- a/admin/src/elements/RefreshButton.jsx
+++ b/admin/src/elements/RefreshButton.jsx
@@ -1,0 +1,23 @@
+import { memo } from 'react';
+import classNames from 'classnames';
+
+import SvgIcon from './SvgIcon';
+import IconButton from './IconButton';
+
+function RefreshButton( { tooltipText, loading, handleRefresh, className } ) {
+	return <IconButton
+		className={ classNames( [
+			'refresh-icon',
+			loading ? 'refreshing' : null,
+			className ? className : null,
+
+		] ) }
+		tooltip={ tooltipText }
+		tooltipClass="align-left-0"
+		onClick={ handleRefresh }
+	>
+		<SvgIcon name="refresh" />
+	</IconButton>;
+}
+
+export default memo( RefreshButton );

--- a/admin/src/elements/RefreshButton.jsx
+++ b/admin/src/elements/RefreshButton.jsx
@@ -1,20 +1,33 @@
-import { memo } from 'react';
+import { memo, useEffect, useState } from 'react';
 import classNames from 'classnames';
 
 import SvgIcon from './SvgIcon';
 import IconButton from './IconButton';
 
 function RefreshButton( { tooltipText, loading, handleRefresh, className } ) {
+	// run reload animation only when reload running using click on this button
+	const [ clicked, setClicked ] = useState( false );
+
+	useEffect( () => {
+		// when reload action finished, stop button animation
+		if ( ! loading ) {
+			setClicked( false );
+		}
+	}, [ loading ] );
+
 	return <IconButton
 		className={ classNames( [
 			'refresh-icon',
-			loading ? 'refreshing' : null,
+			clicked && loading ? 'refreshing' : null,
 			className ? className : null,
 
 		] ) }
 		tooltip={ tooltipText }
 		tooltipClass="align-left-0"
-		onClick={ handleRefresh }
+		onClick={ () => {
+			setClicked( true );
+			handleRefresh();
+		} }
 	>
 		<SvgIcon name="refresh" />
 	</IconButton>;

--- a/admin/src/elements/RefreshTableButton.jsx
+++ b/admin/src/elements/RefreshTableButton.jsx
@@ -3,8 +3,7 @@ import { useQueryClient, useIsFetching } from '@tanstack/react-query';
 import { useI18n } from '@wordpress/react-i18n';
 import { filtersArray } from '../hooks/useFilteringSorting';
 import useTableStore from '../hooks/useTableStore';
-import SvgIcon from './SvgIcon';
-import IconButton from '../elements/IconButton';
+import RefreshButton from './RefreshButton';
 
 function RefreshTableButton( { noCount, defaultSorting } ) {
 	const { __ } = useI18n();
@@ -22,14 +21,14 @@ function RefreshTableButton( { noCount, defaultSorting } ) {
 		}
 	};
 
-	return <IconButton
-		className={ `ml-m refresh-icon ${ fetchingStatus ? 'refreshing' : '' }` }
-		tooltip={ __( 'Refresh table' ) }
-		tooltipClass="align-left-0"
-		onClick={ handleRefresh }
-	>
-		<SvgIcon name="refresh" />
-	</IconButton>;
+	return (
+		<RefreshButton
+			tooltipText={ __( 'Refresh table' ) }
+			handleRefresh={ handleRefresh }
+			className="ml-m"
+			loading={ fetchingStatus }
+		/>
+	);
 }
 
 export default memo( RefreshTableButton );

--- a/admin/src/modules/WebVitals.jsx
+++ b/admin/src/modules/WebVitals.jsx
@@ -66,16 +66,18 @@ const WebVitalsLogs = memo( ( ) => {
 			<TablePanel
 				title={ showTable ? __( 'Web Vitals table' ) : __( 'Web Vitals charts' ) }
 				actionButtons={
-					<ButtonGroup variant="soft">
+					<ButtonGroup size="sm">
 						<Button
-							color={ showTable ? 'neutral' : 'primary' }
+							variant={ showTable ? 'outlined' : 'solid' }
+							color="primary"
 							onClick={ () => setShowTable( false ) }
 							startDecorator={ <SvgIcon name="chart" /> }
 						>
 							{ __( 'Charts' ) }
 						</Button>
 						<Button
-							color={ showTable ? 'primary' : 'neutral' }
+							variant={ showTable ? 'solid' : 'outlined' }
+							color="primary"
 							onClick={ () => setShowTable( true ) }
 							startDecorator={ <SvgIcon name="table" /> }
 						>

--- a/admin/src/modules/WebVitals.jsx
+++ b/admin/src/modules/WebVitals.jsx
@@ -6,11 +6,14 @@ import WebVitalsOverview from '../overview/WebVitals';
 import ModuleViewHeader from '../components/ModuleViewHeader';
 import useModuleSectionRoute from '../hooks/useModuleSectionRoute';
 import { getMapKeysArray } from '../lib/helpers';
+
 import WebVitalsTable from '../tables/WebVitalsTable';
 import WebVitalsCharts from '../charts/WebVitalsCharts.jsx';
 import TablePanel from '../components/TablePanel.jsx';
-import { Button } from '@mui/joy';
 import SvgIcon from '../elements/SvgIcon';
+
+import ButtonGroup from '@mui/joy/ButtonGroup';
+import Button from '@mui/joy/Button';
 
 const SettingsModule = lazy( () => import( `./static/Settings.jsx` ) );
 
@@ -58,24 +61,38 @@ const WebVitalsLogs = memo( ( ) => {
 	const [ showTable, setShowTable ] = useState( false );
 
 	return (
-		<TablePanel
-			title={ showTable ? __( 'Web Vitals table' ) : __( 'Web Vitals charts' ) }
-			actionButton={ <Button
-				variant="soft"
-				onClick={ () => setShowTable( showTable ? false : true ) }
-				startDecorator={ <SvgIcon name={ showTable ? 'chart' : 'table' } /> }
-			>
-				{ showTable ? __( 'Show data on charts' ) : __( 'Show data on table' ) }
-			</Button>
-			}
-			noContentPadding={ showTable }
-		>
-			{ showTable
-				? <WebVitalsTable slug="web-vitals" />
-				:	<WebVitalsCharts slug="web-vitals" />
+		<>
 
-			}
-		</TablePanel>
+			<TablePanel
+				title={ showTable ? __( 'Web Vitals table' ) : __( 'Web Vitals charts' ) }
+				actionButtons={
+					<ButtonGroup variant="soft">
+						<Button
+							color={ showTable ? 'neutral' : 'primary' }
+							onClick={ () => setShowTable( false ) }
+							startDecorator={ <SvgIcon name="chart" /> }
+						>
+							{ __( 'Charts' ) }
+						</Button>
+						<Button
+							color={ showTable ? 'primary' : 'neutral' }
+							onClick={ () => setShowTable( true ) }
+							startDecorator={ <SvgIcon name="table" /> }
+						>
+							{ __( 'Table' ) }
+						</Button>
+					</ButtonGroup>
+				}
+				noContentPadding={ showTable }
+			>
+				{ showTable
+					? <WebVitalsTable slug="web-vitals" />
+					:	<WebVitalsCharts slug="web-vitals" />
+
+				}
+
+			</TablePanel>
+		</>
 
 	);
 } );


### PR DESCRIPTION
**Changes proposed in this Pull Request**
1. switching between charts and table using button tabs

2. fixed datepicker in filters, filters panel was closed after click on day outside the month currently displayed in datepicker (ie. datepicker shows December month and selected was 1st of January)
Click event target element didn't exist in dom anymore so click event was considered as outside click to close panel. Datepicker component rerenders after selection of day outside displayed month to show the month related to already selected day.

3. fixed usage of datepicker default value in filters panel, issue [#2604](https://github.com/QualityUnit/web-issues/issues/2604)
value of datepicker was dispatched to filters global state only on change event, thus `undefined` value was saved into filters if user submitted date filter without manual change of date using datepicker.
Now, date is saved to filters state using effect in both cases, on load of datepicker in panel and on datepicker change event too.

4. Y axis of area charts recompute according to currently visible charts, ie. add/remove some metrics in metric chart legend

5. ability to refetch already rendered charts using refresh button

6. fixed submitting `undefined` value to filters when `string`, `number` and `browser` filters are not changed before saving. issue [#2613](https://github.com/QualityUnit/web-issues/issues/2613)

Close QualityUnit/web-issues#2566
Close QualityUnit/web-issues#2604
Close QualityUnit/web-issues#2600
Close QualityUnit/web-issues#2613