### PR TITLE
feat: serp domains table type column with buttons

### DIFF
--- a/admin/src/onboarding/steps/StepChooseCompetitors.jsx
+++ b/admin/src/onboarding/steps/StepChooseCompetitors.jsx
@@ -6,7 +6,7 @@ import Button from '@mui/joy/Button';
 import useOnboarding from '../../hooks/useOnboarding';
 
 import SvgIcon from '../../elements/SvgIcon';
-import { SingleSelectMenu, SortBy, Table, TooltipSortingFiltering, useInfiniteFetch } from '../../lib/tableImports';
+import { SortBy, Stack, Table, TooltipSortingFiltering, useInfiniteFetch } from '../../lib/tableImports';
 import { domainTypes } from '../../lib/serpUrlColumns';
 import useChangeRow from '../../hooks/useChangeRow';
 import useTableStore from '../../hooks/useTableStore';
@@ -63,10 +63,33 @@ const StepChooseCompetitors = () => {
 
 		columnHelper.accessor( 'domain_type', {
 			filterValMenu: domainTypes,
-			className: 'nolimit',
-			cell: ( cell ) => <SingleSelectMenu autoClose items={ domainTypes } name={ cell.column.id }
-				defaultValue={ cell.getValue() }
-				onChange={ ( newVal ) => updateRow( { newVal, cell } ) } />,
+			cell: ( cell ) => (
+				<Stack direction="row" flexWrap="wrap" spacing={ 0.5 } >
+					{
+						Object.entries( domainTypes ).map( ( [ domainKey, domainName ] ) => {
+							const selected = cell.getValue() === domainKey;
+							return (
+								domainKey !== 'X'
+									? <Button
+										key={ domainKey }
+										size="xs"
+										variant="outlined"
+										color="neutral"
+										sx={ { ...( ! selected && { opacity: 0.5 } ) } }
+										onClick={ () => {
+											if ( ! selected ) {
+												updateRow( { newVal: domainKey, cell } );
+											}
+										} }
+									>
+										{ domainName }
+									</Button>
+									: null
+							);
+						} )
+					}
+				</Stack>
+			),
 			header: ( th ) => <SortBy { ...th } />,
 			size: 80,
 		} ),

--- a/admin/src/tables/SerpTopDomainsTable.jsx
+++ b/admin/src/tables/SerpTopDomainsTable.jsx
@@ -8,7 +8,7 @@ import {
 	Table,
 	ModuleViewHeaderBottom,
 	TooltipSortingFiltering,
-	SingleSelectMenu, TextArea, Button,
+	SingleSelectMenu, TextArea, Button, Stack,
 } from '../lib/tableImports';
 
 import useTableStore from '../hooks/useTableStore';
@@ -16,7 +16,6 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 import { domainTypes } from '../lib/serpUrlColumns';
-import Stack from '@mui/joy/Stack';
 
 const title = __( 'Add Domains' );
 const paginationId = 'domain_id';

--- a/admin/src/tables/SerpTopDomainsTable.jsx
+++ b/admin/src/tables/SerpTopDomainsTable.jsx
@@ -8,7 +8,7 @@ import {
 	Table,
 	ModuleViewHeaderBottom,
 	TooltipSortingFiltering,
-	SingleSelectMenu, TextArea,
+	SingleSelectMenu, TextArea, Button,
 } from '../lib/tableImports';
 
 import useTableStore from '../hooks/useTableStore';
@@ -16,6 +16,7 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTablePanels from '../hooks/useTablePanels';
 import DescriptionBox from '../elements/DescriptionBox';
 import { domainTypes } from '../lib/serpUrlColumns';
+import Stack from '@mui/joy/Stack';
 
 const title = __( 'Add Domains' );
 const paginationId = 'domain_id';
@@ -87,8 +88,33 @@ export default function SerpTopDomainsTable( { slug } ) {
 
 		columnHelper.accessor( 'domain_type', {
 			filterValMenu: domainTypes,
-			className: 'nolimit',
-			cell: ( cell ) => <SingleSelectMenu autoClose items={ domainTypes } name={ cell.column.id } defaultValue={ cell.getValue() } onChange={ ( newVal ) => updateRow( { newVal, cell } ) } />,
+			cell: ( cell ) => (
+				<Stack direction="row" flexWrap="wrap" spacing={ 0.5 } >
+					{
+						Object.entries( domainTypes ).map( ( [ domainKey, domainName ] ) => {
+							const selected = cell.getValue() === domainKey;
+							return (
+								domainKey !== 'X'
+									? <Button
+										key={ domainKey }
+										size="xs"
+										variant="outlined"
+										color="neutral"
+										sx={ { ...( ! selected && { opacity: 0.5 } ) } }
+										onClick={ () => {
+											if ( ! selected ) {
+												updateRow( { newVal: domainKey, cell } );
+											}
+										} }
+									>
+										{ domainName }
+									</Button>
+									: null
+							);
+						} )
+					}
+				</Stack>
+			),
 			header: ( th ) => <SortBy { ...th } />,
 			size: 80,
 		} ),


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Single select dropdown replaced with buttons options in SERP Domains table Type column.
`Uncategorized` option is ignored and not available, as it should not be selected by user.

Close QualityUnit/web-issues#2551
