### PR TITLE
fix: filter remove click event bubbling to parent button

### DIFF
--- a/admin/src/components/TableFilter.jsx
+++ b/admin/src/components/TableFilter.jsx
@@ -114,8 +114,10 @@ export default function TableFilter( { props, onEdit, onRemove, customSlug, cust
 						<Tooltip className="showOnHover">{ __( 'Edit filter' ) }</Tooltip>
 					</div>
 					<div className="flex flex-align-center">
-						<SvgIcon name="close" className="close" onClick={ () => {
+						<SvgIcon name="close" className="close" onClick={ ( e ) => {
 							onRemove( [ key ] );
+							// prevent bubbling of click event to parent button
+							e.stopPropagation();
 						} } />
 						<Tooltip className="showOnHover" style={ { width: '8em' } }>{ __( 'Delete filter' ) }</Tooltip>
 					</div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Table filter remove click acction bubbling to parent button, what caused immediate run of edit click event during filter removal.

Close QualityUnit/web-issues#[2617](https://github.com/QualityUnit/web-issues/issues/2617)
