### PR TITLE
fix: disabled filtering and sorting for Offloaded URL

### DIFF
--- a/admin/src/components/ModuleViewHeaderBottom.jsx
+++ b/admin/src/components/ModuleViewHeaderBottom.jsx
@@ -21,7 +21,7 @@ import RefreshTableButton from '../elements/RefreshTableButton';
 import DeleteSelectedButton from '../elements/DeleteSelectedButton';
 import useColumnTypesQuery from '../queries/useColumnTypesQuery';
 
-export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hideActions, noImport, noInsert, noExport, noCount, noDelete, options, customPanel, customButtons } ) {
+export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hiddenFilters, hideActions, noImport, noInsert, noExport, noCount, noDelete, options, customPanel, customButtons } ) {
 	const { __ } = useI18n();
 	const didMountRef = useRef( false );
 	const panelPopover = useRef();
@@ -103,10 +103,14 @@ export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hi
 							</Button>
 
 							{ state.editFilter === 'addFilter' && // Our main adding panel (only when Add button clicked)
-							<TableFilterPanel ref={ panelPopover } onEdit={ ( val ) => {
-								handleHeaderHeight();
-								handleOnEdit( val );
-							} } />
+							<TableFilterPanel
+								ref={ panelPopover }
+								onEdit={ ( val ) => {
+									handleHeaderHeight();
+									handleOnEdit( val );
+								} }
+								{ ...( hiddenFilters && hiddenFilters.length ? { hiddenFilters } : null ) }
+							/>
 							}
 						</div>
 					}
@@ -130,10 +134,15 @@ export default function ModuleViewHeaderBottom( { noColumnsMenu, noFiltering, hi
 				</div>
 				{ Object.keys( filters ).length !== 0 &&
 				<div className="urlslab-moduleView-headerBottom__bottom mt-l flex flex-align-center">
-					<TableFilter props={ { state } } onEdit={ handleOnEdit } onRemove={ ( key ) => {
-						handleHeaderHeight();
-						handleRemoveFilter( key );
-					} } />
+					<TableFilter
+						props={ { state } }
+						onEdit={ handleOnEdit }
+						onRemove={ ( key ) => {
+							handleHeaderHeight();
+							handleRemoveFilter( key );
+						} }
+						{ ...( hiddenFilters && hiddenFilters.length ? { hiddenFilters } : null ) }
+					/>
 				</div>
 				}
 			</div>

--- a/admin/src/tables/MediaFilesTable.jsx
+++ b/admin/src/tables/MediaFilesTable.jsx
@@ -147,7 +147,7 @@ export default function MediaFilesTable( { slug } ) {
 		columnHelper?.accessor( 'download_url', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <a href={ cell.getValue() } title={ cell.getValue() } target="_blank" rel="noreferrer">{ cell.getValue() }</a>,
-			header: ( th ) => <SortBy { ...th } />,
+			header: header.download_url,
 			size: 100,
 		} ),
 		columnHelper?.accessor( 'filetype', {
@@ -236,6 +236,7 @@ export default function MediaFilesTable( { slug } ) {
 			</DescriptionBox>
 			<ModuleViewHeaderBottom
 				noImport
+				hiddenFilters={ [ 'download_url' ] }
 			/>
 			<Table className="fadeInto"
 				initialState={ { columnVisibility: { width: false, height: false, labels: false } } }


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Disabled filtering and sorting for `Offloaded URL` in Media table.

Close QualityUnit/web-issues#2676
