### PR TITLE
fix: fixed selection of rows in changes panel to show diff

### DIFF
--- a/admin/src/elements/TableSelectCheckbox.jsx
+++ b/admin/src/elements/TableSelectCheckbox.jsx
@@ -4,7 +4,7 @@ import useChangeRow from '../hooks/useChangeRow';
 import useTableStore from '../hooks/useTableStore';
 import Checkbox from './Checkbox';
 
-const TableSelectCheckbox = ( { tableElement, customSlug, className } ) => {
+const TableSelectCheckbox = ( { tableElement, customSlug, className, options } ) => {
 	let slug = useTableStore( ( state ) => state.activeTable );
 	if ( customSlug ) {
 		slug = customSlug;
@@ -14,16 +14,16 @@ const TableSelectCheckbox = ( { tableElement, customSlug, className } ) => {
 	const { selectRows } = useChangeRow( { customSlug: slug } );
 
 	const rowId = tableElement?.row?.id;
-	const isSelectAll = rowId === undefined;
+	const allRows = rowId === undefined;
 
-	const selected = isSelectAll
+	const selected = allRows
 		? selectedAll
 		: selectedRows?.[ rowId ] !== undefined;
 
 	return (
 		<Checkbox
 			value={ selected }
-			onChange={ ( checked ) => selectRows( tableElement, checked, isSelectAll ) }
+			onChange={ ( checked ) => selectRows( { tableElement, checked, allRows, maxRows: options?.maxRows } ) }
 			{ ...( className ? { className } : null ) }
 		/>
 	);


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed selection of rows in changes panel table. 
When two rows were selected, it was not possible to select any other previous checkbox because the first checkbox was immediately deselected when three rows were selected.
- removing of first selected checkbox is done directly before the state of selected rows is saved => do not need to update state with three checkboxes selected and immediately update state again with removed first checkbox
- `selectRows()` method accept maxRows parameter to limit selected rows before they are saved into state

Close QualityUnit/web-issues#2718
