### PR TITLE
[2823] fix: download_url column type not defined, filter not working

### DIFF
--- a/admin/src/tables/MediaFilesTable.jsx
+++ b/admin/src/tables/MediaFilesTable.jsx
@@ -127,7 +127,7 @@ function MediaFilesTable( { slug } ) {
 		columnHelper.accessor( 'download_url', {
 			tooltip: ( cell ) => cell.getValue(),
 			cell: ( cell ) => <a href={ cell.getValue() } title={ cell.getValue() } target="_blank" rel="noreferrer">{ cell.getValue() }</a>,
-			header: header.download_url,
+			header: ( th ) => <SortBy { ...th } />,
 			size: 100,
 		} ),
 		columnHelper.accessor( 'filetype', {

--- a/includes/data/class-urlslab-data-file.php
+++ b/includes/data/class-urlslab-data-file.php
@@ -513,8 +513,6 @@ class Urlslab_Data_File extends Urlslab_Data {
 		switch ( $column ) {
 			case 'status_changed':
 				return self::COLUMN_TYPE_DATE;
-		}
-		switch ( $column ) {
 			case 'download_url':
 				return self::COLUMN_TYPE_STRING;
 		}

--- a/includes/data/class-urlslab-data-file.php
+++ b/includes/data/class-urlslab-data-file.php
@@ -2,22 +2,22 @@
 
 class Urlslab_Data_File extends Urlslab_Data {
 	public const ALTERNATIVE_PROCESSING = 'P';
-	public const ALTERNATIVE_DISABLED = 'D';
-	public const ALTERNATIVE_ERROR = 'E';
+	public const ALTERNATIVE_DISABLED   = 'D';
+	public const ALTERNATIVE_ERROR      = 'E';
 
 	public static $mime_types
 		= array(
-			'txt'  => 'text/plain',
-			'htm'  => 'text/html',
-			'html' => 'text/html',
-			'css'  => 'text/css',
-			'json' => array(
+			'txt'   => 'text/plain',
+			'htm'   => 'text/html',
+			'html'  => 'text/html',
+			'css'   => 'text/css',
+			'json'  => array(
 				'application/json',
 				'text/json',
 			),
-			'xml'  => 'application/xml',
-			'swf'  => 'application/x-shockwave-flash',
-			'flv'  => 'video/x-flv',
+			'xml'   => 'application/xml',
+			'swf'   => 'application/x-shockwave-flash',
+			'flv'   => 'video/x-flv',
 
 			'hqx'   => 'application/mac-binhex40',
 			'cpt'   => 'application/mac-compactpro',
@@ -513,6 +513,10 @@ class Urlslab_Data_File extends Urlslab_Data {
 		switch ( $column ) {
 			case 'status_changed':
 				return self::COLUMN_TYPE_DATE;
+		}
+		switch ( $column ) {
+			case 'download_url':
+				return self::COLUMN_TYPE_STRING;
 		}
 
 		if ( 'filestatus' === $column ) {


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixes not defined download_url column type in Media Files table > filter not available

Close QualityUnit/web-issues#2823