### PR TITLE
feat: user local data handled by global store

### DIFF
--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -7,7 +7,8 @@ import ScopedCssBaseline from '@mui/joy/ScopedCssBaseline';
 
 import useWpMenuWidth from './hooks/useWpMenuWidth';
 import useUserInfo from './hooks/useUserInfo';
-import { useCreateUserLocalDataStorage } from './hooks/useUserLocalData';
+import { useInitUserLocalDataStorage } from './hooks/useUserLocalData';
+
 import useGeneralQuery from './queries/useGeneralQuery';
 import useUserInfoQuery from './queries/useUserInfoQuery';
 import { useModulesQueryPrefetch } from './queries/useModulesQuery';
@@ -40,7 +41,7 @@ const App = () => {
 
 	useModulesQueryPrefetch();
 	useWpMenuWidth();
-	useCreateUserLocalDataStorage();
+	useInitUserLocalDataStorage();
 
 	return (
 		<CacheProvider value={ cache }>

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -7,6 +7,7 @@ import ScopedCssBaseline from '@mui/joy/ScopedCssBaseline';
 
 import useWpMenuWidth from './hooks/useWpMenuWidth';
 import useUserInfo from './hooks/useUserInfo';
+import { useCreateUserLocalDataStorage } from './hooks/useUserLocalData';
 import useGeneralQuery from './queries/useGeneralQuery';
 import useUserInfoQuery from './queries/useUserInfoQuery';
 import { useModulesQueryPrefetch } from './queries/useModulesQuery';
@@ -39,6 +40,7 @@ const App = () => {
 
 	useModulesQueryPrefetch();
 	useWpMenuWidth();
+	useCreateUserLocalDataStorage();
 
 	return (
 		<CacheProvider value={ cache }>

--- a/admin/src/app/router.jsx
+++ b/admin/src/app/router.jsx
@@ -64,14 +64,6 @@ const routes = [
 	...modulesRoutes,
 ];
 
-export const router = createHashRouter( [
-	{
-		path: '/',
-		element: <AppRoot />,
-		children: routes,
-	},
-] );
-
 const useRouter = () => {
 	const groups = useModulesGroups();
 	const r = useMemo( () => {

--- a/admin/src/components/ModuleViewHeader.jsx
+++ b/admin/src/components/ModuleViewHeader.jsx
@@ -1,13 +1,14 @@
-import { Link } from 'react-router-dom';
+import { useCallback, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
-import { update } from 'idb-keyval';
+import { Link } from 'react-router-dom';
+
+import useTableStore from '../hooks/useTableStore';
+import useTablePanels from '../hooks/useTablePanels';
+import useUserLocalData from '../hooks/useUserLocalData';
 
 import SimpleButton from '../elements/SimpleButton';
 
 import '../assets/styles/components/_ModuleViewHeader.scss';
-import { useCallback, useEffect } from 'react';
-import useTableStore from '../hooks/useTableStore';
-import useTablePanels from '../hooks/useTablePanels';
 
 const menuItems = new Map( [
 	[ 'overview', __( 'Overview' ) ],
@@ -17,6 +18,7 @@ const menuItems = new Map( [
 export default function ModuleViewHeader( { moduleId, moduleMenu, activeSection, noSettings } ) {
 	const setActiveTable = useTableStore( ( state ) => state.setActiveTable );
 	const resetPanelsStore = useTablePanels( ( state ) => state.resetPanelsStore );
+	const setUserLocalData = useUserLocalData( ( state ) => state.setUserLocalData );
 
 	useEffect( () => {
 		// Cleaning filtering and sorting etc of table on header loading
@@ -29,10 +31,8 @@ export default function ModuleViewHeader( { moduleId, moduleMenu, activeSection,
 		setActiveTable();
 		resetPanelsStore();
 
-		update( moduleId, ( dbData ) => {
-			return { ...dbData, activeMenu: state };
-		} );
-	}, [ moduleId, resetPanelsStore, setActiveTable ] );
+		setUserLocalData( moduleId, { activeMenu: state } );
+	}, [ moduleId, resetPanelsStore, setActiveTable, setUserLocalData ] );
 
 	const activator = ( menukey ) => menukey === activeSection ? 'active' : '';
 

--- a/admin/src/components/TableBody.jsx
+++ b/admin/src/components/TableBody.jsx
@@ -1,11 +1,14 @@
 import { useEffect, memo, useContext } from 'react';
 
+import useUserLocalData from '../hooks/useUserLocalData';
+
 import TableRow from './TableRow';
 import { TableContext } from './TableComponent';
 
 const TableBody = ( ) => {
 	const tbody = [];
-	const { tableContainerRef, table, slug, userCustomSettings, closeableRowActions } = useContext( TableContext );
+	const { tableContainerRef, table, slug, closeableRowActions } = useContext( TableContext );
+	const openedRowActions = useUserLocalData( ( state ) => state.userData[ slug ]?.openedRowActions === undefined ? true : state.userData[ slug ].openedRowActions );
 
 	const { rows } = table?.getRowModel();
 
@@ -23,7 +26,7 @@ const TableBody = ( ) => {
 		const editRows = tableContainerRef.current.querySelectorAll( 'tr .editRow' );
 		if ( editRows.length ) {
 			editRows.forEach( ( editRow ) => {
-				if ( ! userCustomSettings.openedRowActions ) {
+				if ( ! openedRowActions ) {
 					editRow.addEventListener( 'transitionEnd', () => {
 						editRow.style.display = 'none';
 					} );
@@ -32,7 +35,7 @@ const TableBody = ( ) => {
 				editRow.style.display = 'table-cell';
 			} );
 		}
-	}, [ closeableRowActions, userCustomSettings.openedRowActions, tableContainerRef ] );
+	}, [ closeableRowActions, openedRowActions, tableContainerRef ] );
 
 	for ( const row of rows ) {
 		tbody.push(

--- a/admin/src/components/TableHead.jsx
+++ b/admin/src/components/TableHead.jsx
@@ -21,12 +21,13 @@ const getHeaderCellRealWidth = ( cell ) => {
 };
 
 const TableHead = () => {
-	const { slug, tableContainerRef, table, resizable, userCustomSettings, closeableRowActions } = useContext( TableContext );
+	const { slug, tableContainerRef, table, resizable, closeableRowActions } = useContext( TableContext );
 	const editThRef = useRef();
 	const didMountRef = useRef( false );
 
 	const setUserLocalData = useUserLocalData( ( state ) => state.setUserLocalData );
 	const openedRowActions = useUserLocalData( ( state ) => state.userData[ slug ]?.openedRowActions === undefined ? true : state.userData[ slug ].openedRowActions );
+	const columnVisibility = useUserLocalData( ( state ) => state.userData[ slug ]?.columnVisibility );
 
 	const toggleOpenedRowActions = useCallback( () => {
 		if ( closeableRowActions ) {
@@ -81,7 +82,7 @@ const TableHead = () => {
 		if ( didMountRef.current ) {
 			tableContainerRef.current?.style.setProperty( '--Table-editHeadColumnWidth', `${ editThRef?.current?.clientWidth }px` );
 		}
-	}, [ closeableRowActions, tableContainerRef, userCustomSettings.columnVisibility ] );
+	}, [ closeableRowActions, tableContainerRef, columnVisibility ] );
 
 	useEffect( () => {
 		if ( didMountRef.current ) {

--- a/admin/src/components/TableHead.jsx
+++ b/admin/src/components/TableHead.jsx
@@ -1,14 +1,15 @@
-import { memo, useContext, useEffect, useRef } from 'react';
+import { memo, useCallback, useContext, useEffect, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
-import {
-	flexRender,
-} from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
 
-import { TableContext } from './TableComponent';
+import useUserLocalData from '../hooks/useUserLocalData';
+import SvgIcon from '../elements/SvgIcon';
+
 import Stack from '@mui/joy/Stack';
 import Tooltip from '@mui/joy/Tooltip';
-import SvgIcon from '../elements/SvgIcon';
+
+import { TableContext } from './TableComponent';
 
 const getHeaderCellRealWidth = ( cell ) => {
 	let sortButtonWidth = cell.querySelector( 'button' )?.offsetWidth;
@@ -20,9 +21,18 @@ const getHeaderCellRealWidth = ( cell ) => {
 };
 
 const TableHead = () => {
-	const { tableContainerRef, table, resizable, userCustomSettings, closeableRowActions, toggleOpenedRowActions } = useContext( TableContext );
+	const { slug, tableContainerRef, table, resizable, userCustomSettings, closeableRowActions } = useContext( TableContext );
 	const editThRef = useRef();
 	const didMountRef = useRef( false );
+
+	const setUserLocalData = useUserLocalData( ( state ) => state.setUserLocalData );
+	const openedRowActions = useUserLocalData( ( state ) => state.userData[ slug ]?.openedRowActions === undefined ? true : state.userData[ slug ].openedRowActions );
+
+	const toggleOpenedRowActions = useCallback( () => {
+		if ( closeableRowActions ) {
+			setUserLocalData( slug, { openedRowActions: ! openedRowActions } );
+		}
+	}, [ closeableRowActions, openedRowActions, setUserLocalData, slug ] );
 
 	// set width of columns according to header items width
 	// default width of cells defined in each table is considered as source width which is used if cell header items (sort button and label) doesnt overflow defined width
@@ -100,7 +110,7 @@ const TableHead = () => {
 								key={ header.id }
 								className={ classNames( [
 									header.column.columnDef.className,
-									closeableRowActions && isEditCell && ! userCustomSettings.openedRowActions ? 'closed' : null,
+									closeableRowActions && isEditCell && ! openedRowActions ? 'closed' : null,
 								] ) }
 								data-defaultwidth={ header.getSize() }
 								colSpan={ isEditCell ? 2 : null }
@@ -136,13 +146,13 @@ const TableHead = () => {
 					} )
 					}
 					{ closeableRowActions &&
-						<th className={ `editRow-toggle pos-sticky ${ ! userCustomSettings.openedRowActions ? 'closed' : null }` }>
+						<th className={ `editRow-toggle pos-sticky ${ ! openedRowActions ? 'closed' : null }` }>
 							<Stack className="editRow-toggle-inn"
 								direction="column"
 								justifyContent="center"
 								alignItems="flex-end"
 							>
-								<Tooltip title={ userCustomSettings.openedRowActions ? __( 'Hide rows actions' ) : __( 'Show rows actions' ) }>
+								<Tooltip title={ openedRowActions ? __( 'Hide rows actions' ) : __( 'Show rows actions' ) }>
 									<button className="editRow-toggle-button" onClick={ toggleOpenedRowActions }>
 										<SvgIcon name="chevron" />
 									</button>

--- a/admin/src/components/TableRow.jsx
+++ b/admin/src/components/TableRow.jsx
@@ -1,12 +1,15 @@
 import { useContext } from 'react';
 import classNames from 'classnames';
-import Tooltip from '@mui/joy/Tooltip';
-import Box from '@mui/joy/Box';
 import { flexRender } from '@tanstack/react-table';
 
 import useTableStore from '../hooks/useTableStore';
-import { TableContext } from './TableComponent';
 import useSelectRows from '../hooks/useSelectRows';
+import useUserLocalData from '../hooks/useUserLocalData';
+
+import Tooltip from '@mui/joy/Tooltip';
+import Box from '@mui/joy/Box';
+
+import { TableContext } from './TableComponent';
 
 const TableCellCheckbox = ( { cell, rowId } ) => {
 	const isSelected = useIsSelected( rowId );
@@ -44,10 +47,12 @@ const TableCellCheckbox = ( { cell, rowId } ) => {
 };
 
 function TableCell( { cell, isEditCell } ) {
-	const { resizable, userCustomSettings, closeableRowActions } = useContext( TableContext );
+	const { slug, resizable, closeableRowActions } = useContext( TableContext );
 	const sorting = useTableStore().useSorting();
 	const isTooltip = cell.column.columnDef.tooltip && cell.getValue();
 	const style = typeof cell?.column.columnDef?.style === 'function' ? cell?.column.columnDef?.style( cell ) : cell?.column.columnDef?.style || {};
+
+	const openedRowActions = useUserLocalData( ( state ) => state.userData[ slug ]?.openedRowActions === undefined ? true : state.userData[ slug ].openedRowActions );
 
 	return (
 		cell.column.getIsVisible() &&
@@ -56,7 +61,7 @@ function TableCell( { cell, isEditCell } ) {
 			className={ classNames( [
 				cell.column.columnDef.className,
 				sorting.length && sorting[ 0 ].key === cell.column.columnDef.accessorKey ? 'highlight' : null,
-				closeableRowActions && isEditCell && ! userCustomSettings.openedRowActions ? 'closed' : null,
+				closeableRowActions && isEditCell && ! openedRowActions ? 'closed' : null,
 			] ) }
 			colSpan={ isEditCell ? 2 : null }
 			style={ {

--- a/admin/src/elements/ColumnsMenu.jsx
+++ b/admin/src/elements/ColumnsMenu.jsx
@@ -1,17 +1,16 @@
 import { memo, useEffect, useState, useRef, useCallback } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 
-import { update } from 'idb-keyval';
+import useTableStore from '../hooks/useTableStore';
 
 import Checkbox from './Checkbox';
 import Tooltip from './Tooltip';
+import SvgIcon from './SvgIcon';
 
 import Button from '@mui/joy/Button';
 
-import SvgIcon from './SvgIcon';
 import '../assets/styles/elements/_MultiSelectMenu.scss';
 import '../assets/styles/elements/_ColumnsMenu.scss';
-import useTableStore from '../hooks/useTableStore';
 
 function ColumnsMenu( { className, style, customSlug } ) {
 	const { __ } = useI18n();
@@ -59,10 +58,7 @@ function ColumnsMenu( { className, style, customSlug } ) {
 		}
 
 		column.toggleVisibility();
-		update( slug, ( dbData ) => {
-			return { ...dbData, columnVisibility: table?.getState().columnVisibility };
-		} );
-	}, [ slug, table, tableColumns ] );
+	}, [ tableColumns ] );
 
 	const handleVisibilityAll = useCallback( ( action ) => {
 		if ( action === 'showAllCols' ) {
@@ -76,10 +72,7 @@ function ColumnsMenu( { className, style, customSlug } ) {
 		}
 		setActive( false );
 		setVisible( false );
-		update( slug, ( dbData ) => {
-			return { ...dbData, columnVisibility: table?.getState().columnVisibility };
-		} );
-	}, [ slug, table ] );
+	}, [ table ] );
 
 	const handleMenu = useCallback( () => {
 		setActive( ( s ) => ! s );

--- a/admin/src/hooks/useModuleSectionRoute.jsx
+++ b/admin/src/hooks/useModuleSectionRoute.jsx
@@ -2,37 +2,21 @@
  * Hook to handle opened module section by route
  */
 
-import { useCallback, useEffect, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router-dom';
-import { get } from 'idb-keyval';
+
+import useUserLocalData from './useUserLocalData';
 
 const useModuleSectionRoute = ( availableRoutes, staticId = null ) => {
+	const params = useParams();
 	const { moduleId } = useOutletContext();
 
-	const [ activeSectionData, setActiveSectionData ] = useState( null );
-	const params = useParams();
 	const isRootRoute = Object.keys( params ).length === 0;
-
-	// if it's root module route, check for last visited section
-	const checkLastVisitedTab = useCallback( async () => {
-		if ( isRootRoute ) {
-			const savedData = await get( staticId !== null ? staticId : moduleId );
-			setActiveSectionData( savedData );
-		}
-	}, [ isRootRoute, moduleId, staticId ] );
-
-	useEffect( () => {
-		checkLastVisitedTab();
-	}, [ checkLastVisitedTab ] );
+	const currentId = staticId !== null ? staticId : moduleId;
+	const activeSectionData = useUserLocalData( ( state ) => state.userData[ currentId ] );
 
 	// accessed directly module route without defined section route
-	if ( isRootRoute ) {
-		if ( activeSectionData === undefined ) {
-			// not saved last visited section, return default
-			return 'overview';
-		}
-		// return null if not fetched yet, prevent showing overview while loading from idb-keyval
-		return activeSectionData?.activeMenu ? activeSectionData.activeMenu : null;
+	if ( isRootRoute && activeSectionData && activeSectionData.activeMenu ) {
+		return activeSectionData.activeMenu;
 	}
 
 	// defined section in route, return if defined section route exists

--- a/admin/src/hooks/useOnloadRedirect.jsx
+++ b/admin/src/hooks/useOnloadRedirect.jsx
@@ -10,17 +10,15 @@ import useUserLocalData from './useUserLocalData';
 
 export const homeRoute = '/SEO&Content';
 export const homeTitle = __( 'SEO & Content' );
-const lastActivePageDefault = {};
 
 const useOnloadRedirect = async () => {
 	const checkedRedirection = useRef( false );
 	const { pathname } = useLocation();
 	const navigate = useNavigate();
 	const setUserLocalData = useUserLocalData( ( state ) => state.setUserLocalData );
-	const getUserLocalData = useUserLocalData( ( state ) => state.getUserLocalData );
+	const lastActivePage = useUserLocalData( ( state ) => state.lastActivePage );
 
 	useEffect( () => {
-		const lastActivePage = getUserLocalData( 'lastActivePage', lastActivePageDefault );
 		const isRootRoute = pathname === '/';
 
 		if ( checkedRedirection.current ) {
@@ -47,7 +45,7 @@ const useOnloadRedirect = async () => {
 			}
 			checkedRedirection.current = true;
 		}
-	}, [ navigate, pathname, setUserLocalData, getUserLocalData ] );
+	}, [ lastActivePage, navigate, pathname, setUserLocalData ] );
 };
 
 export default useOnloadRedirect;

--- a/admin/src/hooks/useOnloadRedirect.jsx
+++ b/admin/src/hooks/useOnloadRedirect.jsx
@@ -16,9 +16,10 @@ const useOnloadRedirect = async () => {
 	const { pathname } = useLocation();
 	const navigate = useNavigate();
 	const setUserLocalData = useUserLocalData( ( state ) => state.setUserLocalData );
-	const lastActivePage = useUserLocalData( ( state ) => state.lastActivePage );
+	const getUserLocalData = useUserLocalData( ( state ) => state.getUserLocalData );
 
 	useEffect( () => {
+		const lastActivePage = getUserLocalData( 'lastActivePage' ) || homeRoute;
 		const isRootRoute = pathname === '/';
 
 		if ( checkedRedirection.current ) {
@@ -45,7 +46,7 @@ const useOnloadRedirect = async () => {
 			}
 			checkedRedirection.current = true;
 		}
-	}, [ lastActivePage, navigate, pathname, setUserLocalData ] );
+	}, [ navigate, pathname, setUserLocalData, getUserLocalData ] );
 };
 
 export default useOnloadRedirect;

--- a/admin/src/hooks/useUserLocalData.jsx
+++ b/admin/src/hooks/useUserLocalData.jsx
@@ -27,17 +27,16 @@ const useUserLocalData = create( ( set, get ) => ( {
 	} ),
 
 	// access non-reactive user data value from state
-	getUserLocalData: ( key, fallbackValue ) => {
+	getUserLocalData: ( key, valueKey ) => {
 		if ( key === undefined ) {
 			return get().userData;
 		}
 
-		const value = get().userData[ key ];
-		if ( fallbackValue !== undefined ) {
-			return value !== undefined ? value : fallbackValue;
+		if ( valueKey !== undefined ) {
+			return get().userData[ key ]?.[ valueKey ];
 		}
 
-		return value;
+		return get().userData[ key ];
 	},
 } ) );
 

--- a/admin/src/hooks/useUserLocalData.jsx
+++ b/admin/src/hooks/useUserLocalData.jsx
@@ -6,6 +6,12 @@ const useUserLocalData = create( ( set, get ) => ( {
 	userData: {},
 
 	setUserLocalData: ( key, value ) => set( ( state ) => {
+		if ( typeof value === 'string' ) {
+			update( key, value );
+			return { userData: { ...state.userData, [ key ]: value } };
+		}
+
+		// object value, extend already saved values
 		update( key, ( dbData ) => {
 			return { ...dbData, ...value };
 		} );

--- a/admin/src/hooks/useUserLocalData.jsx
+++ b/admin/src/hooks/useUserLocalData.jsx
@@ -1,10 +1,17 @@
 import { useEffect } from 'react';
 import { create } from 'zustand';
-import { entries } from 'idb-keyval';
+import { entries, update } from 'idb-keyval';
 
 const useUserLocalData = create( ( set, get ) => ( {
 	data: {},
-	setLocalData: ( key, value ) => set( ( state ) => ( { data: { ...state.data, [ key ]: value } } ) ),
+
+	setLocalData: ( key, value ) => set( ( state ) => {
+		update( key, ( dbData ) => {
+			return { ...dbData, ...value };
+		} );
+		return { data: { ...state.data, [ key ]: { ...state.data[ key ], ...value } } };
+	} ),
+
 	setAllLocalData: ( allData ) => set( () => {
 		const data = {};
 		allData.forEach( ( [ key, val ] ) => {

--- a/admin/src/hooks/useUserLocalData.jsx
+++ b/admin/src/hooks/useUserLocalData.jsx
@@ -3,34 +3,47 @@ import { create } from 'zustand';
 import { entries, update } from 'idb-keyval';
 
 const useUserLocalData = create( ( set, get ) => ( {
-	data: {},
+	userData: {},
 
-	setLocalData: ( key, value ) => set( ( state ) => {
+	setUserLocalData: ( key, value ) => set( ( state ) => {
 		update( key, ( dbData ) => {
 			return { ...dbData, ...value };
 		} );
-		return { data: { ...state.data, [ key ]: { ...state.data[ key ], ...value } } };
+		return { userData: { ...state.userData, [ key ]: { ...state.userData[ key ], ...value } } };
 	} ),
 
-	setAllLocalData: ( allData ) => set( () => {
-		const data = {};
+	setAllUserLocalData: ( allData ) => set( () => {
+		const userData = {};
 		allData.forEach( ( [ key, val ] ) => {
-			data[ key ] = val;
+			userData[ key ] = val;
 		} );
-		return { data };
+		return { userData };
 	} ),
-	getLocalData: ( key ) => key !== undefined ? get().data[ key ] : get().data,
+
+	// access non-reactive user data value from state
+	getUserLocalData: ( key, fallbackValue ) => {
+		if ( key === undefined ) {
+			return get().userData;
+		}
+
+		const value = get().userData[ key ];
+		if ( fallbackValue !== undefined ) {
+			return value !== undefined ? value : fallbackValue;
+		}
+
+		return value;
+	},
 } ) );
 
-export const useCreateUserLocalDataStorage = () => {
-	const setAllLocalData = useUserLocalData( ( state ) => state.setAllLocalData );
+export const useInitUserLocalDataStorage = () => {
+	const setAllUserLocalData = useUserLocalData( ( state ) => state.setAllUserLocalData );
 	useEffect( () => {
 		entries().then( ( dbData ) => {
 			if ( dbData ) {
-				setAllLocalData( dbData );
+				setAllUserLocalData( dbData );
 			}
 		} );
-	}, [ setAllLocalData ] );
+	}, [ setAllUserLocalData ] );
 };
 
 export default useUserLocalData;

--- a/admin/src/hooks/useUserLocalData.jsx
+++ b/admin/src/hooks/useUserLocalData.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { create } from 'zustand';
+import { entries } from 'idb-keyval';
+
+const useUserLocalData = create( ( set, get ) => ( {
+	data: {},
+	setLocalData: ( key, value ) => set( ( state ) => ( { data: { ...state.data, [ key ]: value } } ) ),
+	setAllLocalData: ( allData ) => set( () => {
+		const data = {};
+		allData.forEach( ( [ key, val ] ) => {
+			data[ key ] = val;
+		} );
+		return { data };
+	} ),
+	getLocalData: ( key ) => key !== undefined ? get().data[ key ] : get().data,
+} ) );
+
+export const useCreateUserLocalDataStorage = () => {
+	const setAllLocalData = useUserLocalData( ( state ) => state.setAllLocalData );
+	useEffect( () => {
+		entries().then( ( dbData ) => {
+			if ( dbData ) {
+				setAllLocalData( dbData );
+			}
+		} );
+	}, [ setAllLocalData ] );
+};
+
+export default useUserLocalData;


### PR DESCRIPTION
**Changes proposed in this Pull Request**
User data from internal browser database are loaded just once on app load and saved into global store.
benefits:
-- no need to repeatedly call async reading from internal db while user working with app,
-- removed unnecessary rerenders of components which read from internal db because of async read,
-- removed tricky handling of component visibility using css opacity until data from internal db are read to show finally loaded component
-- user data are read instantly from global store

Data are saved into internal db beside the action which save data into store.

Close QualityUnit/urlslab-issues#2
