### PR TITLE
[3232] fix: prepends youtube css before element for cls

### DIFF
--- a/assets/scss/urlslab_youtube_loader_decorated.scss
+++ b/assets/scss/urlslab_youtube_loader_decorated.scss
@@ -165,6 +165,14 @@
 		top: 0;
 	}
 
+	picture,
+	img {
+
+		@media (min-width: $breakpoint-desktop) {
+			height: 24.25em !important;
+		}
+	}
+
 	& &--img {
 		object-fit: cover;
 	}

--- a/includes/widget/class-urlslab-widget-lazy-loading.php
+++ b/includes/widget/class-urlslab-widget-lazy-loading.php
@@ -757,7 +757,7 @@ class Urlslab_Widget_Lazy_Loading extends Urlslab_Widget {
 		} else {
 			$css_link_element->setAttribute( 'href', plugin_dir_url( URLSLAB_PLUGIN_DIR . 'public/build/css/urlslab_youtube_loader_plain.css' ) . 'urlslab_youtube_loader_plain.css' );
 		}
-		$element->insertBefore( $css_link_element );
+		$element->parentNode->prepend( $css_link_element );
 		$this->lazy_load_youtube_css = true;
 	}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixes CLS issue with later appending CSS for youtube decorated window

Close [QualityUnit/urlslab-issues#[ISSUE_NUMBER]](https://github.com/QualityUnit/web-issues/issues/3232)
