### PR TITLE
[1546] - fix: fixed error after click to button "Show URLs where used"

### DIFF
--- a/admin/src/tables/YouTubeCacheTable.jsx
+++ b/admin/src/tables/YouTubeCacheTable.jsx
@@ -72,9 +72,15 @@ function YouTubeCacheTable( { slug } ) {
 		if ( origCell.usage_count > 0 ) {
 			setOptions( [ {
 				detailsOptions: {
-					title: `${ __( 'Video ID', 'urlslab' ) } “${ origCell.videoid }” ${ __( 'is used on these URLs', 'urlslab' ) }`, text: `${ __( 'Video title:', 'urlslab' ) } ${ cell.row._valuesCache.title[ 1 ] }`, slug, url: `${ origCell.videoid }/urls`, showKeys: [ { name: [ 'url_name', __( 'URL', 'urlslab' ) ] } ], listId: 'url_id', counter,
+					title: `${ __( 'Video ID', 'urlslab' ) } “${ origCell.videoid }” ${ __( 'is used on these URLs', 'urlslab' ) }`,
+					text: `${ __( 'Video title:', 'urlslab' ) } ${ cell.row._valuesCache?.title?.[1] || __( 'Unknown title', 'urlslab' ) }`,
+					slug,
+					url: `${ origCell.videoid }/urls`,
+					showKeys: [{ name: ['url_name', __( 'URL', 'urlslab' ) ] }],
+					listId: 'url_id',
+					counter,
 				},
-			} ] );
+			}]);
 		}
 	}, [ setOptions, setRowToEdit, slug ] );
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed error after click to button "Show URLs where used"

**Testing instructions**
- Go to urlslab plugin "Lazy Loading"->"YouTube Videos" and click
"Show URLs where used" button and check console to error and should
to show popup window

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My commits follow the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Close QualityUnit/urlslab-issues#1546
